### PR TITLE
Add lazy loading art carousel

### DIFF
--- a/components/ArtCarousel.js
+++ b/components/ArtCarousel.js
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Image from 'next/image'
+
+const TOTAL_IMAGES = 18
+
+const images = Array.from({ length: TOTAL_IMAGES }, (_, index) => ({
+  src: `/images/art-${index}.png`,
+  alt: `Artwork ${index + 1}`,
+}))
+
+export default function ArtCarousel() {
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  const handleNext = useCallback(() => {
+    setCurrentIndex((previous) => (previous + 1) % TOTAL_IMAGES)
+  }, [])
+
+  const handlePrevious = useCallback(() => {
+    setCurrentIndex((previous) =>
+      (previous - 1 + TOTAL_IMAGES) % TOTAL_IMAGES
+    )
+  }, [])
+
+  const selectImage = useCallback((index) => {
+    setCurrentIndex(index)
+  }, [])
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'ArrowRight') {
+        handleNext()
+      }
+      if (event.key === 'ArrowLeft') {
+        handlePrevious()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [handleNext, handlePrevious])
+
+  const currentImage = useMemo(
+    () => images[currentIndex],
+    [currentIndex]
+  )
+
+  return (
+    <div className="art-carousel">
+      <div className="art-carousel__stage">
+        <Image
+          key={currentImage.src}
+          src={currentImage.src}
+          alt={currentImage.alt}
+          width={1125}
+          height={750}
+          priority={currentIndex === 0}
+          loading={currentIndex === 0 ? undefined : 'lazy'}
+          sizes="(max-width: 768px) 100vw, 1125px"
+          className="next-image art-carousel__image"
+          style={{ width: '100%', height: 'auto' }}
+        />
+      </div>
+
+      <div className="art-carousel__controls" aria-live="polite">
+        <button
+          type="button"
+          onClick={handlePrevious}
+          className="art-carousel__control-button"
+        >
+          Previous
+        </button>
+        <span className="art-carousel__counter">
+          {currentIndex + 1} / {TOTAL_IMAGES}
+        </span>
+        <button
+          type="button"
+          onClick={handleNext}
+          className="art-carousel__control-button"
+        >
+          Next
+        </button>
+      </div>
+
+      <div
+        className="art-carousel__thumbnails"
+        role="list"
+        aria-label="Artwork thumbnails"
+      >
+        {images.map((image, index) => (
+          <button
+            type="button"
+            key={image.src}
+            onClick={() => selectImage(index)}
+            className="art-carousel__thumbnail"
+            aria-label={`Show ${image.alt}`}
+            aria-current={index === currentIndex}
+            role="listitem"
+          >
+            <Image
+              src={image.src}
+              alt={image.alt}
+              width={200}
+              height={133}
+              loading="lazy"
+              sizes="(max-width: 600px) 33vw, 200px"
+              className="art-carousel__thumbnail-image"
+              style={{ width: '100%', height: 'auto' }}
+            />
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/pages/art.mdx
+++ b/pages/art.mdx
@@ -8,25 +8,6 @@ date: 2023-12-24
 
 Here's some of my artwork.
 
-import Image from 'next/image'
+import ArtCarousel from '../components/ArtCarousel'
 
-export function Images() {
-  let arr = []
-  for (let i = 0; i < 18; i++) {
-    arr.push(
-      <Image
-        src={`/images/art-${i}.png`}
-        alt="Art"
-        width={1125}
-        height={750}
-        priority
-        className="next-image"
-        key={i}
-        style={{ marginBottom: '48px' }}
-      />
-    )
-  }
-  return arr
-}
-
-<Images />
+<ArtCarousel />

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -17,8 +17,6 @@ This website is a home for my writing, web-projects and artwork. I write poetry,
 This portfolio is built with **Next.js** and a library called [Nextra](https://nextra.vercel.app/). The source code for this website can be viewed [here](https://github.com/amangrg/web-portfolio).
 
 ---
-
-- Twitter [@amanmakesart](https://twitter.com/amanmakesart)
 - GitHub [@amangrg](https://github.com/amangrg)
 - Linkedin [@amanmakesart](https://www.linkedin.com/in/amanmakesart/)
 - Email amangrg96@gmail.com

--- a/pages/posts/lazy-loading-art-carousel.md
+++ b/pages/posts/lazy-loading-art-carousel.md
@@ -1,0 +1,77 @@
+---
+layout: post
+title: 'Building a Lazy Loading Artwork Carousel'
+description: How I replaced a long image list with a keyboard friendly, lazy loaded carousel
+date: 2024-03-05
+tag: web development
+---
+
+When I first published my art page I dropped eighteen high resolution images on the screen at once. It looked gorgeous but the
+initial load was terrible—every file was fetched eagerly because each `<Image />` component had `priority` enabled. Visitors on
+mobile or slower connections paid the price for my enthusiasm.
+
+I wanted something that felt better to browse and also respected bandwidth, so I built a carousel. Here's how it works.
+
+## 1. Only render the image you need
+
+Instead of mapping over every artwork, the carousel holds an index in React state. The main stage only renders a single
+`<Image />` component bound to that index. Because the rest of the images are not in the tree, Next.js waits to load them until
+they are requested, which slashes the page's initial network waterfall.
+
+```jsx
+const [currentIndex, setCurrentIndex] = useState(0)
+const currentImage = images[currentIndex]
+
+<Image
+  src={currentImage.src}
+  alt={currentImage.alt}
+  priority={currentIndex === 0}
+  loading={currentIndex === 0 ? 'eager' : 'lazy'}
+  sizes="(max-width: 768px) 100vw, 1125px"
+  style={{ width: '100%', height: 'auto' }}
+/>
+```
+
+The very first artwork still uses `priority` so the page feels instant on load, but every subsequent slide is lazy loaded by the
+browser.
+
+## 2. Add friendly controls
+
+Buttons labelled “Previous” and “Next” drive the index forward and backward. I also register left and right arrow keys so that
+browsing with a keyboard feels natural. The active slide indicator (“3 / 18”) updates automatically because it is derived from
+the same piece of state.
+
+```jsx
+useEffect(() => {
+  const handleKeyDown = (event) => {
+    if (event.key === 'ArrowRight') handleNext()
+    if (event.key === 'ArrowLeft') handlePrevious()
+  }
+
+  window.addEventListener('keydown', handleKeyDown)
+  return () => window.removeEventListener('keydown', handleKeyDown)
+}, [handleNext, handlePrevious])
+```
+
+## 3. Lazy thumbnails for quick jumps
+
+Finally, I render a horizontal strip of thumbnail buttons. They use the same Next.js image component but rely on the default
+lazy behaviour. That keeps the DOM light while still giving visitors a fast way to jump directly to a particular illustration.
+
+```jsx
+<button
+  type="button"
+  onClick={() => selectImage(index)}
+  aria-current={index === currentIndex}
+>
+  <Image
+    src={image.src}
+    alt={image.alt}
+    loading="lazy"
+    sizes="(max-width: 600px) 33vw, 200px"
+  />
+</button>
+```
+
+The end result is a page that loads quickly, feels smooth on mobile, and stays fun to explore. I'm excited to keep iterating on
+this pattern for future galleries.

--- a/styles/main.css
+++ b/styles/main.css
@@ -63,3 +63,108 @@ img.next-image {
 .nav-line .nav-link {
   color: #69778c;
 }
+
+.art-carousel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.art-carousel__stage {
+  position: relative;
+  width: 100%;
+  background-color: #f1f5f9;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+}
+
+.art-carousel__stage img {
+  display: block;
+  object-fit: cover;
+}
+
+.art-carousel__controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+.art-carousel__control-button {
+  background-color: #0f172a;
+  color: #f8fafc;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.6rem 1.4rem;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  font-weight: 600;
+}
+
+.art-carousel__control-button:hover,
+.art-carousel__control-button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.18);
+  outline: none;
+}
+
+.art-carousel__control-button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.art-carousel__counter {
+  font-variant-numeric: tabular-nums;
+}
+
+.art-carousel__thumbnails {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(120px, 1fr);
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+  scrollbar-width: thin;
+}
+
+.art-carousel__thumbnails::-webkit-scrollbar {
+  height: 8px;
+}
+
+.art-carousel__thumbnails::-webkit-scrollbar-thumb {
+  background-color: rgba(100, 116, 139, 0.6);
+  border-radius: 9999px;
+}
+
+.art-carousel__thumbnail {
+  border: 2px solid transparent;
+  border-radius: 12px;
+  padding: 0;
+  background: none;
+  cursor: pointer;
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.art-carousel__thumbnail[aria-current='true'] {
+  border-color: #0f172a;
+  transform: translateY(-2px);
+}
+
+.art-carousel__thumbnail-image {
+  border-radius: 10px;
+  display: block;
+}
+
+@media (max-width: 768px) {
+  .art-carousel__control-button {
+    padding: 0.5rem 1.1rem;
+  }
+
+  .art-carousel__thumbnails {
+    grid-auto-columns: minmax(90px, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the art gallery image grid with a keyboard-friendly carousel component that lazily loads slides
- polish the carousel with custom styling for the stage, controls, and thumbnail strip
- remove the Twitter contact link and publish a blog post describing the lazy loading carousel work

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc24d7bbcc83209b88e3738090f586