### PR TITLE
Revamp homepage and add projects showcase

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -6,16 +6,22 @@ date: 2021-03-19
 
 <section className="hero">
   <span className="hero__badge">MS CSE @ Georgia Tech · Full-Stack Engineer</span>
-  <h1>Designing immersive digital experiences powered by data.</h1>
+  <h1>Hi, I'm Aman. I build dependable products for teams who work with data.</h1>
   <p>
-    I'm Aman Garg, a full-stack engineer and machine learning practitioner with 5+ years of
-    experience shipping resilient products across cloud, web, and AI. I build systems that feel
-    effortless for users&mdash;from microfrontends that reach millions of Walmart shoppers to deep
-    learning pipelines reconstructing 3D microscopy in the cloud.
+    I enjoy the messy middle where research, design, and shipping code overlap. I'm finishing an
+    MS in Computational Science and Engineering at Georgia Tech after five years of building
+    production systems at Walmart and Siemens. Lately I've been running cloud pipelines for 3D
+    microscopy at Carl Zeiss XRM and refining machine learning workflows that scientists use every
+    day.
   </p>
   <div className="hero__actions">
     <a className="button" href="/projects">Explore my projects</a>
-    <a className="button button--secondary" href="mailto:aman.garg@gatech.edu">Let's collaborate</a>
+    <a className="button button--secondary" href="mailto:aman.garg@gatech.edu">Email me</a>
+  </div>
+  <div className="hero__socials">
+    <span className="hero__socials-label">Find me on</span>
+    <a href="https://github.com/amangrg" rel="noopener noreferrer">GitHub</a>
+    <a href="https://www.linkedin.com/in/aman9ar9/" rel="noopener noreferrer">LinkedIn</a>
   </div>
 </section>
 
@@ -23,33 +29,37 @@ date: 2021-03-19
   <div className="section__headline">
     <h2>About Me</h2>
     <p>
-      Currently at Georgia Tech honing computational science chops, I translate research-backed
-      insights into human-centered products. Previously at Walmart and Siemens, I led engineering
-      efforts that modernized legacy ecosystems, accelerated releases from months to days, and
-      supported multimillion-dollar contracts. I thrive in interdisciplinary teams where ML models,
-      cloud architecture, and design thinking intersect to solve challenging problems.
+      My path has moved between large platforms and small research groups. At Walmart I helped a
+      cross-functional crew replace a legacy layout system with microfrontends that shipped in days
+      instead of months. At Siemens I earned my stripes handling production incidents while
+      iterating on Active Workspace. Graduate school has added more applied math and signal
+      processing to the mix, which is now showing up in my work on neural data and scientific
+      imaging.
     </p>
   </div>
   <div className="feature-grid">
     <article className="feature-card">
       <h3>Cloud &amp; AI at Scale</h3>
       <p>
-        Migrated a 3D reconstruction suite to Azure with Dockerized services and automated deep
-        learning workflows&mdash;delivering a 10× speed-up for researchers at Carl Zeiss XRM.
+        Moving an in-house 3D reconstruction toolkit to Azure meant containerizing services,
+        building Python pipelines, and tuning GPU workloads. The rework cut processing time for the
+        microscopy team from hours to minutes.
       </p>
     </article>
     <article className="feature-card">
       <h3>Product Velocity</h3>
       <p>
-        Led Walmart's Quick Mods microfrontend initiative, shrinking layout publishing time from six
-        months to ten days and unlocking $200M in business impact.
+        At Walmart I co-led Quick Mods, a project that replaced spreadsheets and manual releases
+        with TypeScript microfrontends. Store layouts now land in production within ten days, which
+        opened the door for merchandising teams to experiment.
       </p>
     </article>
     <article className="feature-card">
       <h3>Human-Centered Engineering</h3>
       <p>
-        Pair rigorous ML experimentation with thoughtful UX&mdash;from EEG-based gameplay insights to
-        interactive pollution visualizations that help communities understand their environment.
+        Whether it's decoding EEG signals or visualizing air quality, I try to ship tools that make
+        complex data approachable. Prototypes only stick when the people who need them can explore
+        and trust the results.
       </p>
     </article>
   </div>
@@ -58,7 +68,7 @@ date: 2021-03-19
 <section className="section">
   <h2 className="section__title">What I'm focusing on</h2>
   <ul className="pill-group">
-    <li className="pill">Scientific &amp; foundation models</li>
+    <li className="pill">Scientific and foundation models</li>
     <li className="pill">Cloud-native data platforms</li>
     <li className="pill">Design systems for analytics tools</li>
     <li className="pill">Realtime geospatial visualizations</li>
@@ -69,17 +79,17 @@ date: 2021-03-19
   <h2 className="section__title">Career snapshot</h2>
   <ol className="timeline">
     <li className="timeline__item">
-      <span className="timeline__period">2025 &ndash; Present</span>
+      <span className="timeline__period">2025 to Present</span>
       <div className="timeline__content">
         <h3>Carl Zeiss XRM · Cloud &amp; AI Intern</h3>
         <p>
-          Building Azure-native pipelines and productionizing denoising and reconstruction models for
-          advanced microscopy workflows.
+          Building Azure-native pipelines and preparing denoising and reconstruction models for
+          everyday use by the microscopy research team.
         </p>
       </div>
     </li>
     <li className="timeline__item">
-      <span className="timeline__period">2021 &ndash; 2024</span>
+      <span className="timeline__period">2021 to 2024</span>
       <div className="timeline__content">
         <h3>Walmart · Software Engineer III</h3>
         <p>
@@ -89,12 +99,12 @@ date: 2021-03-19
       </div>
     </li>
     <li className="timeline__item">
-      <span className="timeline__period">2019 &ndash; 2021</span>
+      <span className="timeline__period">2019 to 2021</span>
       <div className="timeline__content">
         <h3>Siemens · Software Engineer</h3>
         <p>
-          Delivered full-stack upgrades for Active Workspace (React, C++, MySQL) and resolved
-          high-priority incidents to keep enterprise systems online.
+          Delivered full-stack upgrades for Active Workspace (React, C++, MySQL) while resolving
+          high-priority incidents that kept enterprise systems online.
         </p>
       </div>
     </li>
@@ -103,11 +113,11 @@ date: 2021-03-19
 
 <section className="section section--surface">
   <div className="section__headline">
-    <h2>Let's build something remarkable</h2>
+    <h2>Next role</h2>
     <p>
-      I'm exploring Summer 2025 opportunities where engineering craft, ML research, and product
-      sense come together. Reach out if you're building ambitious tools for scientists, creators, or
-      communities.
+      I'm beginning my search for full-time software roles that start in May 2026. If you are
+      building products at the intersection of data, research, and user experience, I'd love to hear
+      from you.
     </p>
   </div>
   <a className="contact-card" href="mailto:aman.garg@gatech.edu">

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,22 +1,118 @@
 ---
 type: page
-title: About
+title: Home
 date: 2021-03-19
 ---
 
-# Aman Garg
+<section className="hero">
+  <span className="hero__badge">MS CSE @ Georgia Tech · Full-Stack Engineer</span>
+  <h1>Designing immersive digital experiences powered by data.</h1>
+  <p>
+    I'm Aman Garg, a full-stack engineer and machine learning practitioner with 5+ years of
+    experience shipping resilient products across cloud, web, and AI. I build systems that feel
+    effortless for users&mdash;from microfrontends that reach millions of Walmart shoppers to deep
+    learning pipelines reconstructing 3D microscopy in the cloud.
+  </p>
+  <div className="hero__actions">
+    <a className="button" href="/projects">Explore my projects</a>
+    <a className="button button--secondary" href="mailto:aman.garg@gatech.edu">Let's collaborate</a>
+  </div>
+</section>
 
-Hey, welcome to my porfolio website and personal blog!
+<section className="section section--surface">
+  <div className="section__headline">
+    <h2>About Me</h2>
+    <p>
+      Currently at Georgia Tech honing computational science chops, I translate research-backed
+      insights into human-centered products. Previously at Walmart and Siemens, I led engineering
+      efforts that modernized legacy ecosystems, accelerated releases from months to days, and
+      supported multimillion-dollar contracts. I thrive in interdisciplinary teams where ML models,
+      cloud architecture, and design thinking intersect to solve challenging problems.
+    </p>
+  </div>
+  <div className="feature-grid">
+    <article className="feature-card">
+      <h3>Cloud &amp; AI at Scale</h3>
+      <p>
+        Migrated a 3D reconstruction suite to Azure with Dockerized services and automated deep
+        learning workflows&mdash;delivering a 10× speed-up for researchers at Carl Zeiss XRM.
+      </p>
+    </article>
+    <article className="feature-card">
+      <h3>Product Velocity</h3>
+      <p>
+        Led Walmart's Quick Mods microfrontend initiative, shrinking layout publishing time from six
+        months to ten days and unlocking $200M in business impact.
+      </p>
+    </article>
+    <article className="feature-card">
+      <h3>Human-Centered Engineering</h3>
+      <p>
+        Pair rigorous ML experimentation with thoughtful UX&mdash;from EEG-based gameplay insights to
+        interactive pollution visualizations that help communities understand their environment.
+      </p>
+    </article>
+  </div>
+</section>
 
-I'm Aman Garg, an ex-Senior dev currently pursuing an MS degree at Georgia Institute of Technology in Computational Science and Engineering. My linkedin profile can be viewed [here](https://www.linkedin.com/in/amanmakesart/). My primary motivation in pursuing this interdisciplinary degree was learning scientific machine learning techniques.
+<section className="section">
+  <h2 className="section__title">What I'm focusing on</h2>
+  <ul className="pill-group">
+    <li className="pill">Scientific &amp; foundation models</li>
+    <li className="pill">Cloud-native data platforms</li>
+    <li className="pill">Design systems for analytics tools</li>
+    <li className="pill">Realtime geospatial visualizations</li>
+  </ul>
+</section>
 
-I am looking for Summer 2025 software dev/ ML internships in the US. If you have any leads for me do reach out at aman.garg@gatech.edu
+<section className="section section--timeline">
+  <h2 className="section__title">Career snapshot</h2>
+  <ol className="timeline">
+    <li className="timeline__item">
+      <span className="timeline__period">2025 &ndash; Present</span>
+      <div className="timeline__content">
+        <h3>Carl Zeiss XRM · Cloud &amp; AI Intern</h3>
+        <p>
+          Building Azure-native pipelines and productionizing denoising and reconstruction models for
+          advanced microscopy workflows.
+        </p>
+      </div>
+    </li>
+    <li className="timeline__item">
+      <span className="timeline__period">2021 &ndash; 2024</span>
+      <div className="timeline__content">
+        <h3>Walmart · Software Engineer III</h3>
+        <p>
+          Shipped microfrontends, SDKs, and React Native tooling that modernized store mapping and
+          release cadence for global retail teams.
+        </p>
+      </div>
+    </li>
+    <li className="timeline__item">
+      <span className="timeline__period">2019 &ndash; 2021</span>
+      <div className="timeline__content">
+        <h3>Siemens · Software Engineer</h3>
+        <p>
+          Delivered full-stack upgrades for Active Workspace (React, C++, MySQL) and resolved
+          high-priority incidents to keep enterprise systems online.
+        </p>
+      </div>
+    </li>
+  </ol>
+</section>
 
-This website is a home for my writing, web-projects and artwork. I write poetry, short stories and make blog posts about things I find fascinating. When not trying to make something new, I like playing chess and listening to music.
-
-This portfolio is built with **Next.js** and a library called [Nextra](https://nextra.vercel.app/). The source code for this website can be viewed [here](https://github.com/amangrg/web-portfolio).
-
----
-- GitHub [@amangrg](https://github.com/amangrg)
-- Linkedin [@amanmakesart](https://www.linkedin.com/in/amanmakesart/)
-- Email amangrg96@gmail.com
+<section className="section section--surface">
+  <div className="section__headline">
+    <h2>Let's build something remarkable</h2>
+    <p>
+      I'm exploring Summer 2025 opportunities where engineering craft, ML research, and product
+      sense come together. Reach out if you're building ambitious tools for scientists, creators, or
+      communities.
+    </p>
+  </div>
+  <a className="contact-card" href="mailto:aman.garg@gatech.edu">
+    <span className="contact-card__label">Email</span>
+    <span className="contact-card__value">aman.garg@gatech.edu</span>
+    <span className="contact-card__cta">Start a conversation →</span>
+  </a>
+</section>

--- a/pages/projects.mdx
+++ b/pages/projects.mdx
@@ -1,0 +1,62 @@
+---
+type: page
+title: Projects
+date: 2024-06-01
+---
+
+<section className="projects-hero">
+  <span className="hero__badge">Selected Work</span>
+  <h1>Engineering stories that blend design, data, and empathy.</h1>
+  <p>
+    Here are two projects that capture how I bridge research and real-world impact&mdash;one brings air
+    quality data to communities, the other decodes brain states from neural signals.
+  </p>
+</section>
+
+<section className="projects-grid">
+  <article className="project-card">
+    <div className="project-card__header">
+      <span className="project-card__tag">Data Visualization · Public Health</span>
+      <h2>USA Pollution Map</h2>
+    </div>
+    <p>
+      Built an interactive leaflet web app that layers AQI, particulate matter, and ozone data across
+      the United States. The experience empowers residents and policy makers to explore temporal
+      trends, compare regions, and surface hotspots using intuitive filters.
+    </p>
+    <ul className="project-card__bullets">
+      <li>Implemented performant map tiling and clustering for nationwide data coverage.</li>
+      <li>Crafted responsive visual storytelling that helped the project become an IEEE BHI finalist.</li>
+      <li>
+        Tech: React, Leaflet, GeoJSON, Netlify. <a href="https://pollutionmap.netlify.app/">Live demo</a>
+        · <a href="https://github.com/amangrg/pollution_map_usa">Source</a>
+      </li>
+    </ul>
+  </article>
+
+  <article className="project-card">
+    <div className="project-card__header">
+      <span className="project-card__tag">Neuroscience · Machine Learning</span>
+      <h2>Brain State Modeling with ARHMMs</h2>
+    </div>
+    <p>
+      Modeled player cognition in esports scenarios by fusing EEG signals with autoregressive hidden
+      Markov models. The pipeline uncovers state transitions that align with high-pressure in-game
+      events and reveals individualized neural signatures.
+    </p>
+    <ul className="project-card__bullets">
+      <li>
+        Engineered frequency-domain feature extraction (delta through gamma bands) using multi-taper
+        spectral analysis to retain discriminative patterns.
+      </li>
+      <li>
+        Evaluated ARHMM, CNN, and logistic regression baselines&mdash;achieving 81% accuracy on kill
+        event detection while highlighting subject-level variability via t-SNE explorations.
+      </li>
+      <li>
+        Tech: Python, NumPy, PyTorch, scikit-learn. <a href="https://github.com/amangrg/eeg-hidden-markov-model">Research repo</a>
+        · <a href="mailto:aman.garg@gatech.edu?subject=EEG%20HMM%20Collab">Request deep dive</a>
+      </li>
+    </ul>
+  </article>
+</section>

--- a/pages/projects.mdx
+++ b/pages/projects.mdx
@@ -6,10 +6,10 @@ date: 2024-06-01
 
 <section className="projects-hero">
   <span className="hero__badge">Selected Work</span>
-  <h1>Engineering stories that blend design, data, and empathy.</h1>
+  <h1>Projects that show how I approach real-world data.</h1>
   <p>
-    Here are two projects that capture how I bridge research and real-world impact&mdash;one brings air
-    quality data to communities, the other decodes brain states from neural signals.
+    Each piece started with a question. How can residents understand changing air quality? What can
+    EEG signals tell coaches about decision making? These are the experiments I'm most proud of.
   </p>
 </section>
 
@@ -20,13 +20,13 @@ date: 2024-06-01
       <h2>USA Pollution Map</h2>
     </div>
     <p>
-      Built an interactive leaflet web app that layers AQI, particulate matter, and ozone data across
-      the United States. The experience empowers residents and policy makers to explore temporal
-      trends, compare regions, and surface hotspots using intuitive filters.
+      An interactive Leaflet web app that brings AQI, particulate matter, and ozone data onto one
+      responsive map of the United States. Local organizers use it to compare regions and explain
+      what is changing to their communities.
     </p>
     <ul className="project-card__bullets">
-      <li>Implemented performant map tiling and clustering for nationwide data coverage.</li>
-      <li>Crafted responsive visual storytelling that helped the project become an IEEE BHI finalist.</li>
+      <li>Implemented custom tiling, clustering, and legends so the map stays responsive at scale.</li>
+      <li>The storytelling work led to an IEEE BHI 2024 finalist spot and invited demos.</li>
       <li>
         Tech: React, Leaflet, GeoJSON, Netlify. <a href="https://pollutionmap.netlify.app/">Live demo</a>
         · <a href="https://github.com/amangrg/pollution_map_usa">Source</a>
@@ -40,19 +40,13 @@ date: 2024-06-01
       <h2>Brain State Modeling with ARHMMs</h2>
     </div>
     <p>
-      Modeled player cognition in esports scenarios by fusing EEG signals with autoregressive hidden
-      Markov models. The pipeline uncovers state transitions that align with high-pressure in-game
-      events and reveals individualized neural signatures.
+      Modeled player cognition in esports scenarios by pairing EEG recordings with autoregressive
+      hidden Markov models. The work surfaces state transitions that line up with high-pressure game
+      moments and highlights how each player responds.
     </p>
     <ul className="project-card__bullets">
-      <li>
-        Engineered frequency-domain feature extraction (delta through gamma bands) using multi-taper
-        spectral analysis to retain discriminative patterns.
-      </li>
-      <li>
-        Evaluated ARHMM, CNN, and logistic regression baselines&mdash;achieving 81% accuracy on kill
-        event detection while highlighting subject-level variability via t-SNE explorations.
-      </li>
+      <li>Engineered frequency-domain features (delta through gamma bands) with multi-taper spectral analysis.</li>
+      <li>Benchmarked ARHMM, CNN, and logistic regression baselines and reached 81% accuracy on kill detection.</li>
       <li>
         Tech: Python, NumPy, PyTorch, scikit-learn. <a href="https://github.com/amangrg/eeg-hidden-markov-model">Research repo</a>
         · <a href="mailto:aman.garg@gatech.edu?subject=EEG%20HMM%20Collab">Request deep dive</a>

--- a/styles/main.css
+++ b/styles/main.css
@@ -24,6 +24,8 @@ body {
   font-variation-settings: 'wght' 450;
   font-variant: common-ligatures contextual;
   letter-spacing: -0.02em;
+  background: radial-gradient(circle at top left, #dbeafe 0%, #f8fafc 55%, #ffffff 100%);
+  color: #0f172a;
 }
 b,
 strong,
@@ -62,6 +64,414 @@ img.next-image {
 
 .nav-line .nav-link {
   color: #69778c;
+}
+
+:root {
+  --surface: rgba(255, 255, 255, 0.75);
+  --surface-strong: #ffffff;
+  --accent: #2563eb;
+  --accent-muted: rgba(37, 99, 235, 0.12);
+  --text-muted: #475569;
+  --border: rgba(148, 163, 184, 0.35);
+}
+
+.hero,
+.section,
+.projects-hero,
+.projects-grid {
+  width: min(980px, 94vw);
+  margin: 0 auto 3.5rem;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(2.75rem, 6vw, 4rem);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(37, 99, 235, 0.8));
+  color: #f8fafc;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.2);
+  isolation: isolate;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.6), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.45), transparent 50%),
+    radial-gradient(circle at 50% 100%, rgba(30, 64, 175, 0.6), transparent 60%);
+  opacity: 0.8;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.hero h1 {
+  font-size: clamp(2.35rem, 4vw, 3.4rem);
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
+}
+
+.hero p {
+  font-size: clamp(1.05rem, 1.8vw, 1.2rem);
+  max-width: 640px;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin-bottom: 1.5rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 1rem;
+  border: 1px solid transparent;
+  background: #f8fafc;
+  color: #0f172a !important;
+  box-shadow: 0 18px 40px rgba(148, 163, 184, 0.28);
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 50px rgba(148, 163, 184, 0.35);
+}
+
+.button:active {
+  transform: translateY(0);
+}
+
+.button--secondary {
+  background: rgba(248, 250, 252, 0.08);
+  color: #f8fafc !important;
+  border-color: rgba(226, 232, 240, 0.4);
+  box-shadow: none;
+}
+
+.button--secondary:hover,
+.button--secondary:focus {
+  background: rgba(248, 250, 252, 0.18);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+}
+
+.section {
+  padding: clamp(2rem, 4vw, 3rem);
+  border-radius: 28px;
+  background: rgba(248, 250, 252, 0.75);
+  box-shadow: 0 25px 55px rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(14px);
+}
+
+.section--surface {
+  background: var(--surface);
+}
+
+.section__headline {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2.25rem;
+}
+
+.section__headline p {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  max-width: 48ch;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-card {
+  padding: 1.75rem;
+  border-radius: 20px;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 35px rgba(100, 116, 139, 0.12);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 28px 48px rgba(71, 85, 105, 0.18);
+}
+
+.feature-card h3 {
+  margin-bottom: 0.75rem;
+}
+
+.feature-card p {
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.section__title {
+  font-size: clamp(1.6rem, 2.5vw, 2.1rem);
+  margin-bottom: 1.5rem;
+}
+
+.pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.pill {
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  background: var(--accent-muted);
+  color: #1d4ed8;
+  font-weight: 600;
+  border: 1px solid rgba(37, 99, 235, 0.25);
+}
+
+.section--timeline {
+  background: var(--surface-strong);
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.75rem;
+  position: relative;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin-left: 1.1rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.35), rgba(15, 23, 42, 0));
+}
+
+.timeline__item {
+  position: relative;
+  padding-left: 2.5rem;
+}
+
+.timeline__item::before {
+  content: '';
+  position: absolute;
+  left: 0.85rem;
+  top: 0.35rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: #2563eb;
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.18);
+}
+
+.timeline__period {
+  display: inline-block;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+}
+
+.timeline__content {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 18px;
+  padding: 1.1rem 1.4rem;
+  border: 1px solid rgba(226, 232, 240, 0.6);
+  box-shadow: 0 16px 30px rgba(148, 163, 184, 0.16);
+}
+
+.timeline__content p {
+  color: var(--text-muted);
+  margin-bottom: 0;
+}
+
+.contact-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.6rem 2rem;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(15, 23, 42, 0.08));
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.contact-card:hover,
+.contact-card:focus {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 45px rgba(37, 99, 235, 0.28);
+}
+
+.contact-card__label {
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: #1d4ed8;
+}
+
+.contact-card__value {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.contact-card__cta {
+  font-weight: 600;
+  color: #1e3a8a;
+}
+
+.projects-hero {
+  padding: clamp(2.25rem, 4vw, 3rem);
+  border-radius: 26px;
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.22);
+  position: relative;
+  overflow: hidden;
+}
+
+.projects-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 30%, rgba(59, 130, 246, 0.5), transparent 60%),
+    radial-gradient(circle at 80% 20%, rgba(96, 165, 250, 0.35), transparent 55%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.projects-hero h1 {
+  position: relative;
+  z-index: 1;
+  font-size: clamp(2.1rem, 3.5vw, 3rem);
+  margin-bottom: 1.2rem;
+}
+
+.projects-hero p,
+.projects-hero .hero__badge {
+  position: relative;
+  z-index: 1;
+}
+
+.projects-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.project-card {
+  padding: clamp(1.8rem, 3vw, 2.4rem);
+  border-radius: 24px;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.1);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.project-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.18);
+}
+
+.project-card__header {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 1.25rem;
+}
+
+.project-card__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.project-card__bullets {
+  margin: 1.4rem 0 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.8rem;
+  color: var(--text-muted);
+}
+
+.project-card__bullets a {
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .hero,
+  .section,
+  .projects-hero,
+  .projects-grid {
+    margin-bottom: 2.5rem;
+  }
+
+  .hero,
+  .projects-hero {
+    border-radius: 22px;
+  }
+
+  .section {
+    border-radius: 22px;
+  }
+
+  .timeline::before {
+    margin-left: 0.8rem;
+  }
+
+  .timeline__item {
+    padding-left: 2rem;
+  }
+
+  .timeline__item::before {
+    left: 0.55rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button,
+  .feature-card,
+  .contact-card,
+  .project-card {
+    transition: none;
+  }
 }
 
 .art-carousel {

--- a/styles/main.css
+++ b/styles/main.css
@@ -24,7 +24,7 @@ body {
   font-variation-settings: 'wght' 450;
   font-variant: common-ligatures contextual;
   letter-spacing: -0.02em;
-  background: radial-gradient(circle at top left, #dbeafe 0%, #f8fafc 55%, #ffffff 100%);
+  background: #e2e8f0;
   color: #0f172a;
 }
 b,
@@ -67,12 +67,12 @@ img.next-image {
 }
 
 :root {
-  --surface: rgba(255, 255, 255, 0.75);
+  --surface: #ffffff;
   --surface-strong: #ffffff;
-  --accent: #2563eb;
+  --accent: #1d4ed8;
   --accent-muted: rgba(37, 99, 235, 0.12);
-  --text-muted: #475569;
-  --border: rgba(148, 163, 184, 0.35);
+  --text-muted: #1f2937;
+  --border: rgba(148, 163, 184, 0.45);
 }
 
 .hero,
@@ -88,9 +88,9 @@ img.next-image {
   overflow: hidden;
   padding: clamp(2.75rem, 6vw, 4rem);
   border-radius: 28px;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(37, 99, 235, 0.8));
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(29, 78, 216, 0.88));
   color: #f8fafc;
-  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.2);
+  box-shadow: 0 36px 70px rgba(15, 23, 42, 0.24);
   isolation: isolate;
 }
 
@@ -115,7 +115,7 @@ img.next-image {
 .hero p {
   font-size: clamp(1.05rem, 1.8vw, 1.2rem);
   max-width: 640px;
-  color: rgba(226, 232, 240, 0.92);
+  color: rgba(241, 245, 249, 0.92);
 }
 
 .hero__badge {
@@ -137,6 +137,42 @@ img.next-image {
   flex-wrap: wrap;
   gap: 1rem;
   margin-top: 2rem;
+}
+
+.hero__socials {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+  align-items: center;
+}
+
+.hero__socials-label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(241, 245, 249, 0.85);
+}
+
+.hero__socials a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #f8fafc !important;
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: transform 150ms ease, background 150ms ease;
+}
+
+.hero__socials a:hover,
+.hero__socials a:focus {
+  transform: translateY(-1px);
+  background: rgba(15, 23, 42, 0.7);
 }
 
 .button {
@@ -181,9 +217,9 @@ img.next-image {
 .section {
   padding: clamp(2rem, 4vw, 3rem);
   border-radius: 28px;
-  background: rgba(248, 250, 252, 0.75);
-  box-shadow: 0 25px 55px rgba(148, 163, 184, 0.18);
-  backdrop-filter: blur(14px);
+  background: var(--surface);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .section--surface {
@@ -197,9 +233,9 @@ img.next-image {
 }
 
 .section__headline p {
-  color: var(--text-muted);
+  color: #334155;
   font-size: 1.05rem;
-  max-width: 48ch;
+  max-width: 58ch;
 }
 
 .feature-grid {
@@ -211,9 +247,9 @@ img.next-image {
 .feature-card {
   padding: 1.75rem;
   border-radius: 20px;
-  background: var(--surface-strong);
-  border: 1px solid var(--border);
-  box-shadow: 0 18px 35px rgba(100, 116, 139, 0.12);
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
   transition: transform 200ms ease, box-shadow 200ms ease;
 }
 
@@ -227,7 +263,7 @@ img.next-image {
 }
 
 .feature-card p {
-  color: var(--text-muted);
+  color: #334155;
   line-height: 1.6;
 }
 
@@ -248,14 +284,14 @@ img.next-image {
 .pill {
   padding: 0.5rem 1.1rem;
   border-radius: 999px;
-  background: var(--accent-muted);
-  color: #1d4ed8;
+  background: rgba(15, 23, 42, 0.06);
+  color: #0f172a;
   font-weight: 600;
-  border: 1px solid rgba(37, 99, 235, 0.25);
+  border: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .section--timeline {
-  background: var(--surface-strong);
+  background: var(--surface);
 }
 
 .timeline {
@@ -303,15 +339,15 @@ img.next-image {
 }
 
 .timeline__content {
-  background: rgba(248, 250, 252, 0.9);
+  background: #f8fafc;
   border-radius: 18px;
   padding: 1.1rem 1.4rem;
-  border: 1px solid rgba(226, 232, 240, 0.6);
-  box-shadow: 0 16px 30px rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
 }
 
 .timeline__content p {
-  color: var(--text-muted);
+  color: #334155;
   margin-bottom: 0;
 }
 
@@ -321,8 +357,8 @@ img.next-image {
   gap: 0.35rem;
   padding: 1.6rem 2rem;
   border-radius: 20px;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(15, 23, 42, 0.08));
-  border: 1px solid rgba(37, 99, 235, 0.25);
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.3);
   text-decoration: none;
   color: inherit;
   transition: transform 200ms ease, box-shadow 200ms ease;
@@ -331,7 +367,7 @@ img.next-image {
 .contact-card:hover,
 .contact-card:focus {
   transform: translateY(-3px);
-  box-shadow: 0 24px 45px rgba(37, 99, 235, 0.28);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.15);
 }
 
 .contact-card__label {
@@ -348,15 +384,15 @@ img.next-image {
 
 .contact-card__cta {
   font-weight: 600;
-  color: #1e3a8a;
+  color: #1d4ed8;
 }
 
 .projects-hero {
   padding: clamp(2.25rem, 4vw, 3rem);
   border-radius: 26px;
-  background: rgba(15, 23, 42, 0.85);
+  background: rgba(15, 23, 42, 0.9);
   color: #f8fafc;
-  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.22);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.24);
   position: relative;
   overflow: hidden;
 }
@@ -392,8 +428,8 @@ img.next-image {
 .project-card {
   padding: clamp(1.8rem, 3vw, 2.4rem);
   border-radius: 24px;
-  background: var(--surface-strong);
-  border: 1px solid var(--border);
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: 0 25px 45px rgba(15, 23, 42, 0.1);
   transition: transform 200ms ease, box-shadow 200ms ease;
 }
@@ -427,7 +463,7 @@ img.next-image {
   padding-left: 1.1rem;
   display: grid;
   gap: 0.8rem;
-  color: var(--text-muted);
+  color: #334155;
 }
 
 .project-card__bullets a {


### PR DESCRIPTION
## Summary
- redesign the homepage with a new hero, experience highlights, timeline, and CTA informed by the latest resume content
- add a dedicated projects page spotlighting the USA pollution visualization and EEG ARHMM research with rich descriptions and links
- expand the global style sheet with gradients, cards, buttons, and layout utilities to support the refreshed visual language

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2f23d0208320aa057d61a5b31a11