### PR TITLE
Revamp portfolio landing and add projects showcase

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -26,6 +26,17 @@ export default function Document() {
         <meta name="twitter:title" content={meta.title} />
         <meta name="twitter:description" content={meta.description} />
         <meta name="twitter:image" content={meta.image} />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try {
+  var d = document.documentElement;
+  d.classList.remove('dark');
+  d.classList.add('light');
+  d.style.colorScheme = 'light';
+  window.localStorage.setItem('theme', 'light');
+} catch (e) { /* noop */ }`
+          }}
+        />
       </Head>
       <body>
         <Main />

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -6,14 +6,17 @@ date: 2021-03-19
 
 # Aman Garg
 
-<div className="hero">
-  <span className="hero__badge">MS CSE @ Georgia Tech · Cloud &amp; AI Intern</span>
+<div className="hero hero--animated">
+  <span className="hero__badge">MS CSE @ Georgia Tech · BRAINML Lab Researcher</span>
   <h1 className="hero__title">Aman Garg</h1>
   <p className="hero__subtitle">
-    Experienced full-stack engineer and ML/cloud specialist with 5+ years building scalable systems and intelligent imaging workflows.
+    Computational scientist and product-minded engineer crafting neural data pipelines and joyful, resilient cloud experiences.
   </p>
   <p className="hero__copy">
-    I design end-to-end products that blend human-centered experiences with rigorous engineering—from Azure-native 3D reconstruction pipelines to high-impact retail microfrontends. Currently, I&apos;m exploring scientific machine learning at Georgia Tech while driving cloud acceleration at Carl Zeiss XRM.
+    At Georgia Tech&apos;s BRAINML Lab, I translate EEG signals into actionable biomarkers while designing systems that honor human context. Previously, I led large-scale product launches at Walmart and Siemens and accelerated scientific imaging at Carl Zeiss XRM.
+  </p>
+  <p className="hero__copy hero__copy--accent">
+    I&apos;m currently exploring full-time applied ML and product engineering roles starting in May 2026—let&apos;s build something cerebral and impactful together.
   </p>
   <div className="hero__cta">
     <a className="button" href="mailto:aman.garg@gatech.edu">Let&apos;s collaborate</a>
@@ -27,18 +30,18 @@ date: 2021-03-19
   </div>
 </div>
 
-<section className="page-section">
+<section className="page-section fade-in">
   <h2 className="section-title">About Me</h2>
   <p>
-    I&apos;m a computational science graduate student at Georgia Tech focused on machine learning for scientific discovery. Before grad school, I led large-scale web initiatives at Walmart and Siemens, shipping microfrontends, SDKs, and production services that touch millions of shoppers worldwide. I thrive when I can pair data-rich systems with thoughtful design to unlock measurable business impact.
+    I&apos;m a computational science graduate student at Georgia Tech focused on machine learning for scientific discovery and neurotechnology. In the BRAINML Lab, I collaborate with neuroscientists to decode EEG data, prototype interpretability tooling, and ship research infrastructure that scales.
   </p>
   <p>
-    Across research and industry, I&apos;ve migrated imaging toolkits to Azure with a <strong>10× speedup</strong>, delivered real-time map editing experiences, and crafted recommendation engines from thousands of academic resources. I&apos;m energized by collaborative teams, generous mentorship, and the chance to translate complex ideas into intuitive, elegant products.
+    Before grad school, I led large-scale web initiatives at Walmart and Siemens, shipping microfrontends, SDKs, and production services that touch millions of shoppers worldwide. Across research and industry, I&apos;ve migrated imaging toolkits to Azure with a <strong>10× speedup</strong>, delivered real-time map editing experiences, and crafted recommendation engines from thousands of academic resources. I thrive when I can pair data-rich systems with thoughtful design to unlock measurable impact.
   </p>
   <div className="highlight-grid">
     <article className="highlight-card">
-      <h3>Cloud &amp; AI Intern · Carl Zeiss XRM</h3>
-      <p>Containerized 3D reconstruction workflows on Azure VMs and automated deep-learning denoising pipelines.</p>
+      <h3>Researcher · BRAINML Lab</h3>
+      <p>Modeling neural attention patterns in EEG recordings and building interactive analysis tooling for scientists.</p>
     </article>
     <article className="highlight-card">
       <h3>Software Engineer III · Walmart</h3>
@@ -51,7 +54,7 @@ date: 2021-03-19
   </div>
 </section>
 
-<section className="page-section">
+<section className="page-section fade-in delay-1">
   <h2 className="section-title">Core Skills</h2>
   <p>
     Modern web stacks, robust ML experimentation, and cloud-native delivery pipelines are the backbone of my work. These are the tools I reach for most often.
@@ -70,12 +73,21 @@ date: 2021-03-19
   </div>
 </section>
 
-<section className="page-section">
+<section className="page-section fade-in delay-2">
   <h2 className="section-title">Recent Experience</h2>
   <div className="experience-grid">
     <article className="experience-card">
+      <h3>Georgia Tech · BRAINML Lab</h3>
+      <span>Graduate Researcher · 2024 – Present</span>
+      <ul>
+        <li>Analyze multi-session EEG datasets to surface biomarkers for cognitive workload and attention.</li>
+        <li>Develop interactive dashboards and signal-processing pipelines that accelerate lab experimentation.</li>
+        <li>Prototype deep learning models and interpretability workflows for real-time neuroadaptive systems.</li>
+      </ul>
+    </article>
+    <article className="experience-card">
       <h3>Carl Zeiss XRM</h3>
-      <span>Cloud &amp; AI Intern · 2025</span>
+      <span>Cloud &amp; AI Engineer · 2025</span>
       <ul>
         <li>Re-architected AI-based 3D reconstruction pipelines on Azure to achieve a 10× performance boost.</li>
         <li>Containerized imaging services with Docker to support microservice-style deployments.</li>
@@ -103,12 +115,12 @@ date: 2021-03-19
   </div>
 </section>
 
-<section className="page-section">
+<section className="page-section fade-in delay-3">
   <h2 className="section-title">Beyond the Resume</h2>
   <p>
-    When I&apos;m not experimenting with neural data or polishing product flows, you&apos;ll find me writing poetry, sketching, or digging into strategy games. I care deeply about mentorship and inclusive tech communities, and I&apos;m actively seeking Summer 2025 software and ML internships in the U.S.
+    When I&apos;m not experimenting with neural data or polishing product flows, you&apos;ll find me writing poetry, sketching, or digging into strategy games. I care deeply about mentorship and inclusive tech communities, and I&apos;m actively building teams that welcome curious collaborators.
   </p>
   <p>
-    If that resonates with you, let&apos;s chat—whether it&apos;s about cloud-native science platforms, creative coding, or your next big idea.
+    I&apos;m looking to join a mission-driven team in May 2026. If that resonates with you, let&apos;s chat—whether it&apos;s about cloud-native science platforms, neuroadaptive interfaces, or your next big idea.
   </p>
 </section>

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -6,17 +6,109 @@ date: 2021-03-19
 
 # Aman Garg
 
-Hey, welcome to my porfolio website and personal blog!
+<div className="hero">
+  <span className="hero__badge">MS CSE @ Georgia Tech · Cloud &amp; AI Intern</span>
+  <h1 className="hero__title">Aman Garg</h1>
+  <p className="hero__subtitle">
+    Experienced full-stack engineer and ML/cloud specialist with 5+ years building scalable systems and intelligent imaging workflows.
+  </p>
+  <p className="hero__copy">
+    I design end-to-end products that blend human-centered experiences with rigorous engineering—from Azure-native 3D reconstruction pipelines to high-impact retail microfrontends. Currently, I&apos;m exploring scientific machine learning at Georgia Tech while driving cloud acceleration at Carl Zeiss XRM.
+  </p>
+  <div className="hero__cta">
+    <a className="button" href="mailto:aman.garg@gatech.edu">Let&apos;s collaborate</a>
+    <a className="button button--ghost" href="/projects">Explore projects</a>
+  </div>
+  <div className="hero__links">
+    <a href="mailto:aman.garg@gatech.edu">Email</a>
+    <a href="https://amangarg.in" target="_blank" rel="noopener noreferrer">Portfolio</a>
+    <a href="https://www.linkedin.com/in/aman9ar9/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+    <a href="https://github.com/amangrg" target="_blank" rel="noopener noreferrer">GitHub</a>
+  </div>
+</div>
 
-I'm Aman Garg, an ex-Senior dev currently pursuing an MS degree at Georgia Institute of Technology in Computational Science and Engineering. My linkedin profile can be viewed [here](https://www.linkedin.com/in/amanmakesart/). My primary motivation in pursuing this interdisciplinary degree was learning scientific machine learning techniques.
+<section className="page-section">
+  <h2 className="section-title">About Me</h2>
+  <p>
+    I&apos;m a computational science graduate student at Georgia Tech focused on machine learning for scientific discovery. Before grad school, I led large-scale web initiatives at Walmart and Siemens, shipping microfrontends, SDKs, and production services that touch millions of shoppers worldwide. I thrive when I can pair data-rich systems with thoughtful design to unlock measurable business impact.
+  </p>
+  <p>
+    Across research and industry, I&apos;ve migrated imaging toolkits to Azure with a <strong>10× speedup</strong>, delivered real-time map editing experiences, and crafted recommendation engines from thousands of academic resources. I&apos;m energized by collaborative teams, generous mentorship, and the chance to translate complex ideas into intuitive, elegant products.
+  </p>
+  <div className="highlight-grid">
+    <article className="highlight-card">
+      <h3>Cloud &amp; AI Intern · Carl Zeiss XRM</h3>
+      <p>Containerized 3D reconstruction workflows on Azure VMs and automated deep-learning denoising pipelines.</p>
+    </article>
+    <article className="highlight-card">
+      <h3>Software Engineer III · Walmart</h3>
+      <p>Led the Quick Mods microfrontend program to cut layout publishing from 6 months to 10 days, contributing to a $200M revenue uplift.</p>
+    </article>
+    <article className="highlight-card">
+      <h3>IEEE BHI Finalist</h3>
+      <p>Built an interactive U.S. pollution map spotlighting environmental health disparities and civic storytelling.</p>
+    </article>
+  </div>
+</section>
 
-I am looking for Summer 2025 software dev/ ML internships in the US. If you have any leads for me do reach out at aman.garg@gatech.edu
+<section className="page-section">
+  <h2 className="section-title">Core Skills</h2>
+  <p>
+    Modern web stacks, robust ML experimentation, and cloud-native delivery pipelines are the backbone of my work. These are the tools I reach for most often.
+  </p>
+  <div className="skill-badges">
+    <span className="skill-badge">Python</span>
+    <span className="skill-badge">TypeScript</span>
+    <span className="skill-badge">React &amp; Next.js</span>
+    <span className="skill-badge">PyTorch</span>
+    <span className="skill-badge">TensorFlow</span>
+    <span className="skill-badge">Azure</span>
+    <span className="skill-badge">Docker &amp; Kubernetes</span>
+    <span className="skill-badge">CI/CD</span>
+    <span className="skill-badge">Data Visualization</span>
+    <span className="skill-badge">GraphQL &amp; REST</span>
+  </div>
+</section>
 
-This website is a home for my writing, web-projects and artwork. I write poetry, short stories and make blog posts about things I find fascinating. When not trying to make something new, I like playing chess and listening to music.
+<section className="page-section">
+  <h2 className="section-title">Recent Experience</h2>
+  <div className="experience-grid">
+    <article className="experience-card">
+      <h3>Carl Zeiss XRM</h3>
+      <span>Cloud &amp; AI Intern · 2025</span>
+      <ul>
+        <li>Re-architected AI-based 3D reconstruction pipelines on Azure to achieve a 10× performance boost.</li>
+        <li>Containerized imaging services with Docker to support microservice-style deployments.</li>
+        <li>Integrated deep-learning denoising into automated scientific workflows for researchers.</li>
+      </ul>
+    </article>
+    <article className="experience-card">
+      <h3>Walmart</h3>
+      <span>Software Engineer III · 2021 – 2024</span>
+      <ul>
+        <li>Directed the Quick Mods microfrontend rollout, cutting layout publishing time to 10 days.</li>
+        <li>Published a StoreMap embedding SDK on NPM and supported a React Native app for on-the-go updates.</li>
+        <li>Collaborated with product and design partners to launch omnichannel experiences with measurable lift.</li>
+      </ul>
+    </article>
+    <article className="experience-card">
+      <h3>Siemens</h3>
+      <span>Software Engineer · 2019 – 2021</span>
+      <ul>
+        <li>Shipped full-stack features for the Active Workspace platform across React, C++, and MySQL services.</li>
+        <li>Resolved P0 production incidents under aggressive SLAs in a globally distributed codebase.</li>
+        <li>Partnered with enterprise customers to secure multimillion-dollar contracts.</li>
+      </ul>
+    </article>
+  </div>
+</section>
 
-This portfolio is built with **Next.js** and a library called [Nextra](https://nextra.vercel.app/). The source code for this website can be viewed [here](https://github.com/amangrg/web-portfolio).
-
----
-- GitHub [@amangrg](https://github.com/amangrg)
-- Linkedin [@amanmakesart](https://www.linkedin.com/in/amanmakesart/)
-- Email amangrg96@gmail.com
+<section className="page-section">
+  <h2 className="section-title">Beyond the Resume</h2>
+  <p>
+    When I&apos;m not experimenting with neural data or polishing product flows, you&apos;ll find me writing poetry, sketching, or digging into strategy games. I care deeply about mentorship and inclusive tech communities, and I&apos;m actively seeking Summer 2025 software and ML internships in the U.S.
+  </p>
+  <p>
+    If that resonates with you, let&apos;s chat—whether it&apos;s about cloud-native science platforms, creative coding, or your next big idea.
+  </p>
+</section>

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -75,42 +75,62 @@ date: 2021-03-19
 
 <section className="page-section fade-in delay-2">
   <h2 className="section-title">Recent Experience</h2>
-  <div className="experience-grid">
-    <article className="experience-card">
-      <h3>Georgia Tech · BRAINML Lab</h3>
-      <span>Graduate Researcher · 2024 – Present</span>
-      <ul>
-        <li>Analyze multi-session EEG datasets to surface biomarkers for cognitive workload and attention.</li>
-        <li>Develop interactive dashboards and signal-processing pipelines that accelerate lab experimentation.</li>
-        <li>Prototype deep learning models and interpretability workflows for real-time neuroadaptive systems.</li>
-      </ul>
+  <div className="experience-timeline">
+    <article className="timeline-entry">
+      <div className="timeline-entry__meta">
+        <span className="timeline-entry__date">2024 – Present</span>
+      </div>
+      <div className="timeline-entry__card">
+        <h3>Georgia Tech · BRAINML Lab</h3>
+        <p className="timeline-entry__role">Graduate Researcher</p>
+        <ul>
+          <li>Analyze multi-session EEG datasets to surface biomarkers for cognitive workload and attention.</li>
+          <li>Develop interactive dashboards and signal-processing pipelines that accelerate lab experimentation.</li>
+          <li>Prototype deep learning models and interpretability workflows for real-time neuroadaptive systems.</li>
+        </ul>
+      </div>
     </article>
-    <article className="experience-card">
-      <h3>Carl Zeiss XRM</h3>
-      <span>Cloud &amp; AI Engineer · 2025</span>
-      <ul>
-        <li>Re-architected AI-based 3D reconstruction pipelines on Azure to achieve a 10× performance boost.</li>
-        <li>Containerized imaging services with Docker to support microservice-style deployments.</li>
-        <li>Integrated deep-learning denoising into automated scientific workflows for researchers.</li>
-      </ul>
+    <article className="timeline-entry">
+      <div className="timeline-entry__meta">
+        <span className="timeline-entry__date">2025</span>
+      </div>
+      <div className="timeline-entry__card">
+        <h3>Carl Zeiss XRM</h3>
+        <p className="timeline-entry__role">Cloud &amp; AI Engineer</p>
+        <ul>
+          <li>Re-architected AI-based 3D reconstruction pipelines on Azure to achieve a 10× performance boost.</li>
+          <li>Containerized imaging services with Docker to support microservice-style deployments.</li>
+          <li>Integrated deep-learning denoising into automated scientific workflows for researchers.</li>
+        </ul>
+      </div>
     </article>
-    <article className="experience-card">
-      <h3>Walmart</h3>
-      <span>Software Engineer III · 2021 – 2024</span>
-      <ul>
-        <li>Directed the Quick Mods microfrontend rollout, cutting layout publishing time to 10 days.</li>
-        <li>Published a StoreMap embedding SDK on NPM and supported a React Native app for on-the-go updates.</li>
-        <li>Collaborated with product and design partners to launch omnichannel experiences with measurable lift.</li>
-      </ul>
+    <article className="timeline-entry">
+      <div className="timeline-entry__meta">
+        <span className="timeline-entry__date">2021 – 2024</span>
+      </div>
+      <div className="timeline-entry__card">
+        <h3>Walmart</h3>
+        <p className="timeline-entry__role">Software Engineer III</p>
+        <ul>
+          <li>Directed the Quick Mods microfrontend rollout, cutting layout publishing time to 10 days.</li>
+          <li>Published a StoreMap embedding SDK on NPM and supported a React Native app for on-the-go updates.</li>
+          <li>Collaborated with product and design partners to launch omnichannel experiences with measurable lift.</li>
+        </ul>
+      </div>
     </article>
-    <article className="experience-card">
-      <h3>Siemens</h3>
-      <span>Software Engineer · 2019 – 2021</span>
-      <ul>
-        <li>Shipped full-stack features for the Active Workspace platform across React, C++, and MySQL services.</li>
-        <li>Resolved P0 production incidents under aggressive SLAs in a globally distributed codebase.</li>
-        <li>Partnered with enterprise customers to secure multimillion-dollar contracts.</li>
-      </ul>
+    <article className="timeline-entry">
+      <div className="timeline-entry__meta">
+        <span className="timeline-entry__date">2019 – 2021</span>
+      </div>
+      <div className="timeline-entry__card">
+        <h3>Siemens</h3>
+        <p className="timeline-entry__role">Software Engineer</p>
+        <ul>
+          <li>Shipped full-stack features for the Active Workspace platform across React, C++, and MySQL services.</li>
+          <li>Resolved P0 production incidents under aggressive SLAs in a globally distributed codebase.</li>
+          <li>Partnered with enterprise customers to secure multimillion-dollar contracts.</li>
+        </ul>
+      </div>
     </article>
   </div>
 </section>

--- a/pages/projects.mdx
+++ b/pages/projects.mdx
@@ -1,0 +1,80 @@
+---
+type: page
+title: Projects
+date: 2024-06-01
+---
+<div className="page-hero">
+  <span className="page-hero__eyebrow">Selected Work</span>
+  <h1>Projects</h1>
+  <p>
+    A closer look at the systems, visualizations, and scientific tooling I build. Each project weaves together product intuition,
+    rigorous engineering, and thoughtful storytelling.
+  </p>
+</div>
+
+<section className="page-section">
+  <div className="project-grid">
+    <article className="project-card">
+      <span className="project-card__tag">Data Storytelling</span>
+      <h2>Visualization of U.S. Air Pollution</h2>
+      <p>
+        An interactive map experience that layers EPA data, satellite imagery, and public health context to make air quality
+        disparities tangible. The experience powers civic discussions and was recognized as an IEEE BHI 2024 finalist.
+      </p>
+      <ul className="project-meta">
+        <li>
+          <strong>Highlights:</strong> Dynamic filtering across pollutants and seasons, animation-ready time series, and direct calls
+          to action for environmental advocates.
+        </li>
+        <li><strong>Stack:</strong> React, Leaflet, Python ETL, Netlify, Mapbox basemaps.</li>
+      </ul>
+      <div className="project-links">
+        <a className="button" href="https://pollutionmap.netlify.app/" target="_blank" rel="noopener noreferrer">
+          Live Demo
+        </a>
+        <a
+          className="button button--ghost"
+          href="https://github.com/amangrg/pollution_map_usa"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub Repo
+        </a>
+      </div>
+    </article>
+    <article className="project-card">
+      <span className="project-card__tag">Neuroscience ML</span>
+      <h2>Brain State Modeling with Hidden Markov Models</h2>
+      <p>
+        A computational neuroscience study decoding player performance in MOBA games from EEG signals. Autoregressive HMMs and
+        convolutional models reveal the neural signatures of high-intensity kill and death events while surfacing subject-level
+        variability in attention.
+      </p>
+      <ul className="project-meta">
+        <li>
+          <strong>Highlights:</strong> Achieved 81% accuracy on high-signal subjects, uncovered band power features linked to in-game
+          actions, and compared HMMs with logistic regression baselines.
+        </li>
+        <li><strong>Stack:</strong> Python, PyTorch, NumPy, SciPy, Matplotlib, t-SNE visualization.</li>
+      </ul>
+      <div className="project-links">
+        <a
+          className="button button--ghost"
+          href="https://github.com/amangrg/eeg-hidden-markov-model"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub Repo
+        </a>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section className="page-section">
+  <h2 className="section-title">Let&apos;s Build What&apos;s Next</h2>
+  <p>
+    I&apos;m continually iterating on these projects—deploying richer datasets, adding predictive insights, and refining storytelling.
+    Have an idea or a dataset you want to bring to life? Reach out at <a href="mailto:aman.garg@gatech.edu">aman.garg@gatech.edu</a>.
+  </p>
+</section>

--- a/styles/main.css
+++ b/styles/main.css
@@ -34,6 +34,99 @@ body {
   background-attachment: fixed;
   color: #0f172a;
   min-height: 100vh;
+  text-rendering: optimizeLegibility;
+}
+
+:root {
+  color: #0f172a;
+}
+
+main article {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: min(1180px, calc(100vw - 3rem));
+}
+
+@media (max-width: 768px) {
+  main article {
+    max-width: calc(100vw - 2rem);
+  }
+}
+
+main article :where(p, li, span, a, strong) {
+  color: #0f172a;
+}
+
+main article :where(h1, h2, h3, h4) {
+  color: #0f172a;
+}
+
+main article a {
+  color: #1d4ed8;
+  text-decoration-color: rgba(59, 130, 246, 0.35);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  transition: color 150ms ease, text-decoration-color 150ms ease;
+}
+
+main article a:hover,
+main article a:focus {
+  color: #4338ca;
+  text-decoration-color: rgba(67, 56, 202, 0.6);
+}
+
+@keyframes floatGlow {
+  0% {
+    transform: translateY(12px) scale(0.97);
+    opacity: 0;
+  }
+  60% {
+    transform: translateY(-4px) scale(1.01);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes softPulse {
+  0%,
+  100% {
+    box-shadow: 0 35px 70px rgba(15, 23, 42, 0.32);
+  }
+  50% {
+    box-shadow: 0 42px 85px rgba(59, 130, 246, 0.38);
+  }
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeInUp 0.85s ease forwards;
+}
+
+.fade-in.delay-1 {
+  animation-delay: 0.15s;
+}
+
+.fade-in.delay-2 {
+  animation-delay: 0.3s;
+}
+
+.fade-in.delay-3 {
+  animation-delay: 0.45s;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 b,
 strong,
@@ -190,6 +283,23 @@ img.next-image {
   box-shadow: 0 35px 70px rgba(15, 23, 42, 0.35);
 }
 
+.hero.hero--animated {
+  animation: floatGlow 1.2s ease forwards;
+  animation-delay: 0.05s;
+}
+
+.hero.hero--animated::before {
+  content: '';
+  position: absolute;
+  inset: auto auto -18% -22%;
+  width: clamp(180px, 35vw, 260px);
+  height: clamp(180px, 35vw, 260px);
+  background: radial-gradient(circle, rgba(244, 114, 182, 0.52), transparent 70%);
+  filter: blur(18px);
+  opacity: 0.8;
+  animation: softPulse 6s ease-in-out infinite;
+}
+
 .hero::after {
   content: '';
   position: absolute;
@@ -237,6 +347,14 @@ img.next-image {
   font-size: 1.05rem;
   line-height: 1.8;
   margin-bottom: 2rem;
+}
+
+.hero__copy--accent {
+  background: rgba(248, 250, 252, 0.12);
+  border-left: 3px solid rgba(250, 204, 21, 0.65);
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.25);
 }
 
 .hero__cta {
@@ -311,6 +429,7 @@ img.next-image {
   margin-bottom: 2.75rem;
   box-shadow: 0 25px 60px rgba(15, 23, 42, 0.1);
   backdrop-filter: blur(4px);
+  transition: transform 350ms ease, box-shadow 350ms ease;
 }
 
 .section-title {
@@ -323,6 +442,11 @@ img.next-image {
   line-height: 1.8;
   font-size: 1.02rem;
   color: #1e293b;
+}
+
+.page-section:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 32px 75px rgba(15, 23, 42, 0.14);
 }
 
 .highlight-grid {
@@ -338,6 +462,7 @@ img.next-image {
   padding: 1.75rem;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.2);
+  transition: transform 220ms ease, box-shadow 220ms ease;
 }
 
 .highlight-card h3 {
@@ -349,6 +474,11 @@ img.next-image {
 .highlight-card p {
   margin: 0;
   color: #334155;
+}
+
+.highlight-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 22px 45px rgba(30, 64, 175, 0.2);
 }
 
 .experience-grid {
@@ -364,11 +494,26 @@ img.next-image {
   background: rgba(241, 245, 249, 0.9);
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  position: relative;
+  overflow: hidden;
+}
+
+.experience-card::after {
+  content: '';
+  position: absolute;
+  inset: auto auto -20% -20%;
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle, rgba(129, 140, 248, 0.2), transparent 70%);
+  z-index: 0;
+  transition: transform 220ms ease, opacity 220ms ease;
 }
 
 .experience-card h3 {
   margin-top: 0;
   margin-bottom: 0.25rem;
+  position: relative;
+  z-index: 1;
 }
 
 .experience-card span {
@@ -376,6 +521,8 @@ img.next-image {
   font-size: 0.9rem;
   color: #475569;
   margin-bottom: 1rem;
+  position: relative;
+  z-index: 1;
 }
 
 .experience-card ul {
@@ -384,6 +531,13 @@ img.next-image {
   display: grid;
   gap: 0.65rem;
   color: #334155;
+  position: relative;
+  z-index: 1;
+}
+
+.experience-card:hover::after {
+  transform: translate(10%, -10%);
+  opacity: 0.9;
 }
 
 .skill-badges {
@@ -400,6 +554,13 @@ img.next-image {
   color: #1e3a8a;
   font-weight: 600;
   font-size: 0.9rem;
+  transition: transform 200ms ease, background-color 200ms ease, box-shadow 200ms ease;
+}
+
+.skill-badge:hover {
+  transform: translateY(-3px);
+  background: rgba(14, 165, 233, 0.18);
+  box-shadow: 0 12px 25px rgba(14, 165, 233, 0.22);
 }
 
 .page-hero {

--- a/styles/main.css
+++ b/styles/main.css
@@ -44,7 +44,7 @@ body {
 main article {
   margin-left: auto;
   margin-right: auto;
-  max-width: min(1180px, calc(100vw - 3rem));
+  max-width: min(1320px, calc(100vw - 3rem));
 }
 
 @media (max-width: 768px) {
@@ -164,7 +164,13 @@ img.next-image {
 }
 
 .nav-line .nav-link {
-  color: #69778c;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.nav-line .nav-link:hover,
+.nav-line .nav-link:focus {
+  color: #1d4ed8;
 }
 
 .art-carousel {
@@ -322,17 +328,21 @@ img.next-image {
   gap: 0.5rem;
   padding: 0.45rem 1.1rem;
   border-radius: 9999px;
-  background-color: rgba(248, 250, 252, 0.15);
+  background-color: rgba(248, 250, 252, 0.22);
+  color: rgba(248, 250, 252, 0.94);
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.72rem;
   font-weight: 600;
   margin-bottom: 1.25rem;
+  text-shadow: 0 6px 18px rgba(15, 23, 42, 0.55);
 }
 
 .hero__title {
   font-size: clamp(2.75rem, 5vw, 4.5rem);
   margin: 0 0 1rem;
+  color: #f8fafc;
+  text-shadow: 0 18px 45px rgba(15, 23, 42, 0.55);
 }
 
 .hero__subtitle {
@@ -340,6 +350,8 @@ img.next-image {
   max-width: 680px;
   margin-bottom: 1.5rem;
   line-height: 1.6;
+  color: rgba(241, 245, 249, 0.95);
+  text-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
 }
 
 .hero__copy {
@@ -347,14 +359,16 @@ img.next-image {
   font-size: 1.05rem;
   line-height: 1.8;
   margin-bottom: 2rem;
+  color: rgba(226, 232, 240, 0.92);
 }
 
 .hero__copy--accent {
-  background: rgba(248, 250, 252, 0.12);
+  background: rgba(248, 250, 252, 0.22);
+  color: rgba(241, 245, 249, 0.97);
   border-left: 3px solid rgba(250, 204, 21, 0.65);
   padding: 1rem 1.25rem;
   border-radius: 18px;
-  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.25);
+  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.35);
 }
 
 .hero__cta {
@@ -373,15 +387,33 @@ img.next-image {
 }
 
 .hero__links a {
-  color: rgba(248, 250, 252, 0.9);
+  position: relative;
+  color: rgba(248, 250, 252, 0.96);
   text-decoration: none;
   transition: color 150ms ease, transform 150ms ease;
+}
+
+.hero__links a::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 -4px;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(248, 250, 252, 0.2), rgba(255, 255, 255, 0.75));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 180ms ease;
+  opacity: 0.85;
 }
 
 .hero__links a:hover,
 .hero__links a:focus {
   color: #e0f2fe;
   transform: translateY(-1px);
+}
+
+.hero__links a:hover::after,
+.hero__links a:focus::after {
+  transform: scaleX(1);
 }
 
 .button {
@@ -423,10 +455,10 @@ img.next-image {
 }
 
 .page-section {
-  background: rgba(255, 255, 255, 0.82);
+  background: rgba(255, 255, 255, 0.92);
   border-radius: 28px;
-  padding: clamp(1.75rem, 3.5vw, 2.5rem);
-  margin-bottom: 2.75rem;
+  padding: clamp(1.85rem, 3.5vw, 2.7rem);
+  margin-bottom: 2.25rem;
   box-shadow: 0 25px 60px rgba(15, 23, 42, 0.1);
   backdrop-filter: blur(4px);
   transition: transform 350ms ease, box-shadow 350ms ease;
@@ -435,13 +467,13 @@ img.next-image {
 .section-title {
   font-size: clamp(1.75rem, 3vw, 2.3rem);
   margin-bottom: 1.5rem;
-  color: #1e293b;
+  color: #0b1120;
 }
 
 .page-section p {
   line-height: 1.8;
   font-size: 1.02rem;
-  color: #1e293b;
+  color: #0f172a;
 }
 
 .page-section:hover {
@@ -469,11 +501,12 @@ img.next-image {
   margin-top: 0;
   margin-bottom: 0.75rem;
   font-size: 1.2rem;
+  color: #0b1120;
 }
 
 .highlight-card p {
   margin: 0;
-  color: #334155;
+  color: #0f172a;
 }
 
 .highlight-card:hover {
@@ -481,63 +514,169 @@ img.next-image {
   box-shadow: 0 22px 45px rgba(30, 64, 175, 0.2);
 }
 
-.experience-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.75rem;
-  margin-top: 1.75rem;
-}
-
-.experience-card {
-  border-radius: 20px;
-  padding: 1.75rem;
-  background: rgba(241, 245, 249, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+.experience-timeline {
+  --timeline-offset: clamp(0.85rem, 2.5vw, 1.2rem);
+  --timeline-marker-size: 0.85rem;
   position: relative;
-  overflow: hidden;
+  display: grid;
+  gap: clamp(1.25rem, 2.5vw, 2.15rem);
+  margin-top: clamp(1.25rem, 2.5vw, 2.1rem);
+  padding-left: calc(var(--timeline-offset) + 0.75rem);
 }
 
-.experience-card::after {
+.experience-timeline::before {
   content: '';
   position: absolute;
-  inset: auto auto -20% -20%;
-  width: 180px;
-  height: 180px;
-  background: radial-gradient(circle, rgba(129, 140, 248, 0.2), transparent 70%);
+  top: 0.75rem;
+  bottom: 0.75rem;
+  left: var(--timeline-offset);
+  width: 3px;
+  border-radius: 9999px;
+  background: linear-gradient(
+    180deg,
+    rgba(148, 163, 184, 0),
+    rgba(148, 163, 184, 0.45) 12%,
+    rgba(59, 130, 246, 0.55) 88%,
+    rgba(59, 130, 246, 0)
+  );
+  pointer-events: none;
+}
+
+.timeline-entry {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.35fr) 1fr;
+  gap: clamp(1.25rem, 2.75vw, 2.25rem);
+  align-items: start;
+}
+
+.timeline-entry__meta {
+  position: relative;
+  padding-left: calc(var(--timeline-offset) + 1.6rem);
+  color: #0b1120;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.timeline-entry__meta::before {
+  content: '';
+  position: absolute;
+  left: calc(var(--timeline-offset) - var(--timeline-marker-size) / 2);
+  top: 0.4rem;
+  width: var(--timeline-marker-size);
+  height: var(--timeline-marker-size);
+  border-radius: 9999px;
+  background: #facc15;
+  box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.25), 0 14px 28px rgba(15, 23, 42, 0.25);
+  transition: transform 220ms ease, box-shadow 220ms ease;
+  z-index: 1;
+}
+
+.timeline-entry__date {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.95rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  color: #0b1120;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+}
+
+.timeline-entry__card {
+  position: relative;
+  border-radius: 22px;
+  padding: clamp(1.5rem, 3vw, 2.2rem);
+  background: rgba(248, 250, 252, 0.94);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.timeline-entry__card::after {
+  content: '';
+  position: absolute;
+  inset: auto -15% -35% auto;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgba(96, 165, 250, 0.18), transparent 70%);
   z-index: 0;
   transition: transform 220ms ease, opacity 220ms ease;
 }
 
-.experience-card h3 {
+.timeline-entry__card h3 {
   margin-top: 0;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.35rem;
+  position: relative;
+  z-index: 1;
+  color: #0b1120;
+}
+
+.timeline-entry__role {
+  margin: 0 0 1.1rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #0f172a;
   position: relative;
   z-index: 1;
 }
 
-.experience-card span {
-  display: block;
-  font-size: 0.9rem;
-  color: #475569;
-  margin-bottom: 1rem;
-  position: relative;
-  z-index: 1;
-}
-
-.experience-card ul {
+.timeline-entry__card ul {
   padding-left: 1.1rem;
   margin: 0;
   display: grid;
-  gap: 0.65rem;
-  color: #334155;
+  gap: 0.6rem;
+  color: #0f172a;
   position: relative;
   z-index: 1;
 }
 
-.experience-card:hover::after {
-  transform: translate(10%, -10%);
-  opacity: 0.9;
+.timeline-entry__card li {
+  line-height: 1.75;
+}
+
+.timeline-entry:hover .timeline-entry__card {
+  transform: translateY(-8px);
+  box-shadow: 0 32px 70px rgba(30, 64, 175, 0.18);
+}
+
+.timeline-entry:hover .timeline-entry__card::after {
+  transform: translate(-6%, -18%);
+  opacity: 0.95;
+}
+
+.timeline-entry:hover .timeline-entry__meta::before {
+  transform: scale(1.15);
+  box-shadow: 0 0 0 6px rgba(250, 204, 21, 0.3), 0 18px 32px rgba(15, 23, 42, 0.28);
+}
+
+@media (max-width: 900px) {
+  .timeline-entry {
+    grid-template-columns: minmax(140px, 0.45fr) 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .experience-timeline {
+    padding-left: calc(var(--timeline-offset) + 0.25rem);
+  }
+
+  .timeline-entry {
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+  }
+
+  .timeline-entry__meta {
+    padding-left: calc(var(--timeline-offset) + 1.4rem);
+  }
+
+  .timeline-entry__card {
+    padding: 1.5rem;
+  }
 }
 
 .skill-badges {

--- a/styles/main.css
+++ b/styles/main.css
@@ -32,13 +32,58 @@ body {
     radial-gradient(circle at 100% 0%, rgba(45, 212, 191, 0.28), transparent 45%),
     #f8fafc;
   background-attachment: fixed;
-  color: #0f172a;
+  color: var(--text-primary);
   min-height: 100vh;
   text-rendering: optimizeLegibility;
 }
 
 :root {
-  color: #0f172a;
+  --text-primary: #1f2937;
+  --text-heading: #16213b;
+  color: var(--text-primary);
+}
+
+.nx-prose {
+  --tw-prose-body: var(--text-primary);
+  --tw-prose-headings: var(--text-heading);
+  --tw-prose-lead: var(--text-primary);
+  --tw-prose-links: #1d4ed8;
+  --tw-prose-bold: var(--text-heading);
+  --tw-prose-counters: var(--text-primary);
+  --tw-prose-bullets: var(--text-primary);
+  --tw-prose-hr: #cbd5f5;
+  --tw-prose-quotes: var(--text-heading);
+  --tw-prose-quote-borders: #cbd5f5;
+  --tw-prose-captions: #334155;
+  --tw-prose-code: var(--text-heading);
+  --tw-prose-pre-code: var(--text-primary);
+  --tw-prose-pre-bg: #f1f5f9;
+  --tw-prose-th-borders: var(--text-heading);
+  --tw-prose-td-borders: #cbd5e1;
+  color: var(--text-primary);
+}
+
+.nx-prose :where(p,
+    li,
+    span,
+    strong,
+    em,
+    blockquote,
+    figcaption,
+    code,
+    a) {
+  color: inherit;
+}
+
+.nextra-content :where(p,
+    li,
+    span,
+    strong,
+    em,
+    blockquote,
+    figcaption,
+    code) {
+  color: var(--text-primary);
 }
 
 main article {
@@ -54,11 +99,11 @@ main article {
 }
 
 main article :where(p, li, span, a, strong) {
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 main article :where(h1, h2, h3, h4) {
-  color: #0f172a;
+  color: var(--text-heading);
 }
 
 main article a {
@@ -164,7 +209,7 @@ img.next-image {
 }
 
 .nav-line .nav-link {
-  color: #0f172a;
+  color: var(--text-heading);
   font-weight: 600;
 }
 
@@ -428,6 +473,7 @@ img.next-image {
   text-decoration: none;
   transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
   box-shadow: 0 18px 35px rgba(250, 204, 21, 0.35);
+  line-height: 1.1;
 }
 
 .button:hover,
@@ -467,13 +513,13 @@ img.next-image {
 .section-title {
   font-size: clamp(1.75rem, 3vw, 2.3rem);
   margin-bottom: 1.5rem;
-  color: #0b1120;
+  color: var(--text-heading);
 }
 
 .page-section p {
   line-height: 1.8;
   font-size: 1.02rem;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .page-section:hover {
@@ -501,12 +547,12 @@ img.next-image {
   margin-top: 0;
   margin-bottom: 0.75rem;
   font-size: 1.2rem;
-  color: #0b1120;
+  color: var(--text-heading);
 }
 
 .highlight-card p {
   margin: 0;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .highlight-card:hover {
@@ -552,7 +598,7 @@ img.next-image {
 .timeline-entry__meta {
   position: relative;
   padding-left: calc(var(--timeline-offset) + 1.6rem);
-  color: #0b1120;
+  color: var(--text-heading);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -579,7 +625,7 @@ img.next-image {
   padding: 0.35rem 0.95rem;
   border-radius: 9999px;
   background: rgba(148, 163, 184, 0.2);
-  color: #0b1120;
+  color: var(--text-heading);
   font-size: 0.78rem;
   letter-spacing: 0.12em;
 }
@@ -611,7 +657,7 @@ img.next-image {
   margin-bottom: 0.35rem;
   position: relative;
   z-index: 1;
-  color: #0b1120;
+  color: var(--text-heading);
 }
 
 .timeline-entry__role {
@@ -620,7 +666,7 @@ img.next-image {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--text-heading);
   position: relative;
   z-index: 1;
 }
@@ -630,7 +676,7 @@ img.next-image {
   margin: 0;
   display: grid;
   gap: 0.6rem;
-  color: #0f172a;
+  color: var(--text-primary);
   position: relative;
   z-index: 1;
 }
@@ -719,13 +765,13 @@ img.next-image {
   margin-top: 0.75rem;
   margin-bottom: 1rem;
   font-size: clamp(2.2rem, 4vw, 3rem);
-  color: #0f172a;
+  color: var(--text-heading);
 }
 
 .page-hero p {
   max-width: 640px;
   font-size: 1.05rem;
-  color: #1e293b;
+  color: var(--text-primary);
 }
 
 .project-grid {
@@ -758,13 +804,13 @@ img.next-image {
   margin-top: 1rem;
   margin-bottom: 1rem;
   font-size: clamp(1.8rem, 3vw, 2.2rem);
-  color: #0f172a;
+  color: var(--text-heading);
 }
 
 .project-card p {
   margin-top: 0;
   margin-bottom: 1.5rem;
-  color: #1e293b;
+  color: var(--text-primary);
   line-height: 1.75;
 }
 
@@ -780,6 +826,28 @@ img.next-image {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+}
+
+.project-links .button {
+  padding: 0.7rem 1.5rem;
+}
+
+.project-links .button.button--ghost {
+  background-color: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8 !important;
+  border: 1px solid rgba(59, 130, 246, 0.24);
+  box-shadow: 0 12px 28px rgba(59, 130, 246, 0.18);
+}
+
+.project-links .button.button--ghost:hover,
+.project-links .button.button--ghost:focus {
+  background-color: rgba(59, 130, 246, 0.18);
+  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.2);
+}
+
+.project-links .button.button--ghost:active {
+  background-color: rgba(59, 130, 246, 0.14);
+  box-shadow: 0 10px 22px rgba(59, 130, 246, 0.16);
 }
 
 @media (max-width: 640px) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -24,6 +24,16 @@ body {
   font-variation-settings: 'wght' 450;
   font-variant: common-ligatures contextual;
   letter-spacing: -0.02em;
+  background: radial-gradient(
+        circle at 0% 0%,
+        rgba(129, 140, 248, 0.3),
+        transparent 55%
+      ),
+    radial-gradient(circle at 100% 0%, rgba(45, 212, 191, 0.28), transparent 45%),
+    #f8fafc;
+  background-attachment: fixed;
+  color: #0f172a;
+  min-height: 100vh;
 }
 b,
 strong,
@@ -166,5 +176,328 @@ img.next-image {
 
   .art-carousel__thumbnails {
     grid-auto-columns: minmax(90px, 1fr);
+  }
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(2.5rem, 5vw, 4.5rem);
+  margin-bottom: 3.5rem;
+  border-radius: 32px;
+  background: linear-gradient(135deg, #0f172a 0%, #312e81 45%, #1e40af 100%);
+  color: #f8fafc;
+  box-shadow: 0 35px 70px rgba(15, 23, 42, 0.35);
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: -20% -30% auto auto;
+  width: clamp(220px, 40vw, 320px);
+  height: clamp(220px, 40vw, 320px);
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.55), transparent 70%);
+  filter: blur(12px);
+  opacity: 0.65;
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1.1rem;
+  border-radius: 9999px;
+  background-color: rgba(248, 250, 252, 0.15);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+}
+
+.hero__title {
+  font-size: clamp(2.75rem, 5vw, 4.5rem);
+  margin: 0 0 1rem;
+}
+
+.hero__subtitle {
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  max-width: 680px;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.hero__copy {
+  max-width: 680px;
+  font-size: 1.05rem;
+  line-height: 1.8;
+  margin-bottom: 2rem;
+}
+
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.hero__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.hero__links a {
+  color: rgba(248, 250, 252, 0.9);
+  text-decoration: none;
+  transition: color 150ms ease, transform 150ms ease;
+}
+
+.hero__links a:hover,
+.hero__links a:focus {
+  color: #e0f2fe;
+  transform: translateY(-1px);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.6rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  background-color: #facc15;
+  color: #0f172a !important;
+  text-decoration: none;
+  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+  box-shadow: 0 18px 35px rgba(250, 204, 21, 0.35);
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 40px rgba(250, 204, 21, 0.45);
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: 0 14px 25px rgba(250, 204, 21, 0.35);
+}
+
+.button.button--ghost {
+  background-color: rgba(248, 250, 252, 0.2);
+  color: #f8fafc !important;
+  box-shadow: none;
+  border: 1px solid rgba(248, 250, 252, 0.4);
+}
+
+.button.button--ghost:hover,
+.button.button--ghost:focus {
+  background-color: rgba(248, 250, 252, 0.3);
+  box-shadow: none;
+}
+
+.page-section {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 28px;
+  padding: clamp(1.75rem, 3.5vw, 2.5rem);
+  margin-bottom: 2.75rem;
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(4px);
+}
+
+.section-title {
+  font-size: clamp(1.75rem, 3vw, 2.3rem);
+  margin-bottom: 1.5rem;
+  color: #1e293b;
+}
+
+.page-section p {
+  line-height: 1.8;
+  font-size: 1.02rem;
+  color: #1e293b;
+}
+
+.highlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.highlight-card {
+  background: linear-gradient(135deg, #e0f2fe 0%, #f8fafc 100%);
+  border-radius: 22px;
+  padding: 1.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.highlight-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.2rem;
+}
+
+.highlight-card p {
+  margin: 0;
+  color: #334155;
+}
+
+.experience-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+  margin-top: 1.75rem;
+}
+
+.experience-card {
+  border-radius: 20px;
+  padding: 1.75rem;
+  background: rgba(241, 245, 249, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.experience-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.25rem;
+}
+
+.experience-card span {
+  display: block;
+  font-size: 0.9rem;
+  color: #475569;
+  margin-bottom: 1rem;
+}
+
+.experience-card ul {
+  padding-left: 1.1rem;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+  color: #334155;
+}
+
+.skill-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.skill-badge {
+  padding: 0.55rem 1.1rem;
+  border-radius: 9999px;
+  background: rgba(30, 64, 175, 0.08);
+  color: #1e3a8a;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.page-hero {
+  text-align: left;
+  margin-bottom: 2.5rem;
+}
+
+.page-hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: #475569;
+  font-weight: 700;
+}
+
+.page-hero h1 {
+  margin-top: 0.75rem;
+  margin-bottom: 1rem;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  color: #0f172a;
+}
+
+.page-hero p {
+  max-width: 640px;
+  font-size: 1.05rem;
+  color: #1e293b;
+}
+
+.project-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.project-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.12);
+}
+
+.project-card__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 1rem;
+  border-radius: 9999px;
+  background: rgba(14, 165, 233, 0.16);
+  color: #0c4a6e;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.project-card h2 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  font-size: clamp(1.8rem, 3vw, 2.2rem);
+  color: #0f172a;
+}
+
+.project-card p {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: #1e293b;
+  line-height: 1.75;
+}
+
+.project-meta {
+  margin: 0 0 1.75rem;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.7rem;
+  color: #334155;
+}
+
+.project-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    border-radius: 24px;
+    padding: 2.25rem;
+  }
+
+  .hero__cta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .page-section {
+    padding: 1.6rem;
+  }
+
+  .project-card {
+    padding: 1.6rem;
   }
 }

--- a/theme.config.js
+++ b/theme.config.js
@@ -1,6 +1,7 @@
 const YEAR = new Date().getFullYear()
 
 export default {
+  darkMode: false,
   footer: (
     <small style={{ display: 'block', marginTop: '8rem' }}>
       <time>{YEAR}</time> © Aman Garg.


### PR DESCRIPTION
## Summary
- redesign the about page with a feature hero, experience highlights, and internship call to action based on updated resume content
- refresh global styling with gradients, cards, and reusable buttons for a more engaging presentation
- add a dedicated projects page highlighting the U.S. air pollution visualization and brain state modeling work

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2f23d0208320aa057d61a5b31a11