### PR TITLE
Refresh home and projects content and styling

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -7,13 +7,13 @@ date: 2021-03-19
 # Aman Garg
 
 <div className="hero">
-  <span className="hero__badge">MS CSE @ Georgia Tech · Cloud &amp; AI Intern</span>
+  <span className="hero__badge">MS CSE @ Georgia Tech · Researcher, BRAINML Lab</span>
   <h1 className="hero__title">Aman Garg</h1>
   <p className="hero__subtitle">
-    Experienced full-stack engineer and ML/cloud specialist with 5+ years building scalable systems and intelligent imaging workflows.
+    Machine learning engineer translating neural signals and product strategy into resilient, human-centered experiences.
   </p>
   <p className="hero__copy">
-    I design end-to-end products that blend human-centered experiences with rigorous engineering—from Azure-native 3D reconstruction pipelines to high-impact retail microfrontends. Currently, I&apos;m exploring scientific machine learning at Georgia Tech while driving cloud acceleration at Carl Zeiss XRM.
+    I build end-to-end products that blend compassionate UX with rigorous engineering—from Azure-native 3D reconstruction pipelines to high-impact retail microfrontends. Now, I&apos;m advancing brain-computer interface research at Georgia Tech&apos;s <a href="https://sites.google.com/view/brainml/home" target="_blank" rel="noopener noreferrer">BRAINML Lab</a>, modeling cognitive state transitions from EEG data and crafting reproducible tooling. I&apos;m actively exploring full-time machine learning and applied research roles starting May 2026.
   </p>
   <div className="hero__cta">
     <a className="button" href="mailto:aman.garg@gatech.edu">Let&apos;s collaborate</a>
@@ -22,6 +22,7 @@ date: 2021-03-19
   <div className="hero__links">
     <a href="mailto:aman.garg@gatech.edu">Email</a>
     <a href="https://amangarg.in" target="_blank" rel="noopener noreferrer">Portfolio</a>
+    <a href="https://sites.google.com/view/brainml/home" target="_blank" rel="noopener noreferrer">BRAINML Lab</a>
     <a href="https://www.linkedin.com/in/aman9ar9/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
     <a href="https://github.com/amangrg" target="_blank" rel="noopener noreferrer">GitHub</a>
   </div>
@@ -30,15 +31,15 @@ date: 2021-03-19
 <section className="page-section">
   <h2 className="section-title">About Me</h2>
   <p>
-    I&apos;m a computational science graduate student at Georgia Tech focused on machine learning for scientific discovery. Before grad school, I led large-scale web initiatives at Walmart and Siemens, shipping microfrontends, SDKs, and production services that touch millions of shoppers worldwide. I thrive when I can pair data-rich systems with thoughtful design to unlock measurable business impact.
+    I&apos;m a computational science graduate student at Georgia Tech focused on machine learning for scientific discovery. In the BRAINML Lab, I lead EEG modeling and experiment tooling that reveal how teams collaborate under pressure. Before grad school, I led large-scale web initiatives at Walmart and Siemens, shipping microfrontends, SDKs, and production services that touched millions of shoppers worldwide.
   </p>
   <p>
-    Across research and industry, I&apos;ve migrated imaging toolkits to Azure with a <strong>10× speedup</strong>, delivered real-time map editing experiences, and crafted recommendation engines from thousands of academic resources. I&apos;m energized by collaborative teams, generous mentorship, and the chance to translate complex ideas into intuitive, elegant products.
+    Across research and industry, I&apos;ve migrated imaging toolkits to Azure with a <strong>10× speedup</strong>, delivered real-time map editing experiences, and crafted recommendation engines from thousands of academic resources. I&apos;m energized by collaborative teams, generous mentorship, and the chance to translate complex ideas into intuitive, elegant products—and I&apos;m ready to bring that energy to a full-time role in 2026.
   </p>
   <div className="highlight-grid">
     <article className="highlight-card">
-      <h3>Cloud &amp; AI Intern · Carl Zeiss XRM</h3>
-      <p>Containerized 3D reconstruction workflows on Azure VMs and automated deep-learning denoising pipelines.</p>
+      <h3>BRAINML Lab · Georgia Tech</h3>
+      <p>Modeling neural dynamics from EEG signals and building reproducible pipelines for human-machine teaming research.</p>
     </article>
     <article className="highlight-card">
       <h3>Software Engineer III · Walmart</h3>
@@ -74,12 +75,12 @@ date: 2021-03-19
   <h2 className="section-title">Recent Experience</h2>
   <div className="experience-grid">
     <article className="experience-card">
-      <h3>Carl Zeiss XRM</h3>
-      <span>Cloud &amp; AI Intern · 2025</span>
+      <h3>Georgia Tech · BRAINML Lab</h3>
+      <span>Graduate Researcher · 2024 – Present</span>
       <ul>
-        <li>Re-architected AI-based 3D reconstruction pipelines on Azure to achieve a 10× performance boost.</li>
-        <li>Containerized imaging services with Docker to support microservice-style deployments.</li>
-        <li>Integrated deep-learning denoising into automated scientific workflows for researchers.</li>
+        <li>Analyze high-density EEG datasets to model team coordination, designing pipelines that turn raw biosignals into actionable insights.</li>
+        <li>Prototype deep learning architectures for cognitive state detection and evaluate their robustness across subjects.</li>
+        <li>Build experiment automation and visualization tooling that accelerates collaboration between neuroscientists and engineers.</li>
       </ul>
     </article>
     <article className="experience-card">
@@ -106,9 +107,9 @@ date: 2021-03-19
 <section className="page-section">
   <h2 className="section-title">Beyond the Resume</h2>
   <p>
-    When I&apos;m not experimenting with neural data or polishing product flows, you&apos;ll find me writing poetry, sketching, or digging into strategy games. I care deeply about mentorship and inclusive tech communities, and I&apos;m actively seeking Summer 2025 software and ML internships in the U.S.
+    When I&apos;m not experimenting with neural data or polishing product flows, you&apos;ll find me writing poetry, sketching, or digging into strategy games. I care deeply about mentorship and inclusive tech communities, and I&apos;m actively preparing for full-time machine learning and applied research roles starting May 2026.
   </p>
   <p>
-    If that resonates with you, let&apos;s chat—whether it&apos;s about cloud-native science platforms, creative coding, or your next big idea.
+    If that resonates with you, let&apos;s chat—whether it&apos;s about cloud-native science platforms, creative coding, or the future team I can help scale next.
   </p>
 </section>

--- a/pages/projects.mdx
+++ b/pages/projects.mdx
@@ -8,7 +8,7 @@ date: 2024-06-01
   <h1>Projects</h1>
   <p>
     A closer look at the systems, visualizations, and scientific tooling I build. Each project weaves together product intuition,
-    rigorous engineering, and thoughtful storytelling.
+    rigorous engineering, and thoughtful storytelling—including ongoing EEG research with Georgia Tech&apos;s BRAINML Lab.
   </p>
 </div>
 
@@ -76,5 +76,6 @@ date: 2024-06-01
   <p>
     I&apos;m continually iterating on these projects—deploying richer datasets, adding predictive insights, and refining storytelling.
     Have an idea or a dataset you want to bring to life? Reach out at <a href="mailto:aman.garg@gatech.edu">aman.garg@gatech.edu</a>.
+    I&apos;m also exploring full-time machine learning and applied research roles beginning May 2026.
   </p>
 </section>

--- a/styles/main.css
+++ b/styles/main.css
@@ -14,6 +14,14 @@
   font-named-instance: 'Italic';
 }
 
+:root {
+  --page-max-width: min(1180px, calc(100vw - 4rem));
+  --page-max-width-compact: calc(100vw - 2.5rem);
+  --text-primary: #020617;
+  --text-secondary: #1e293b;
+  --surface-elevated: rgba(255, 255, 255, 0.92);
+}
+
 body {
   font-family: 'Inter var', system-ui, -apple-system, BlinkMacSystemFont,
     'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
@@ -32,9 +40,31 @@ body {
     radial-gradient(circle at 100% 0%, rgba(45, 212, 191, 0.28), transparent 45%),
     #f8fafc;
   background-attachment: fixed;
-  color: #0f172a;
+  color: var(--text-primary);
   min-height: 100vh;
+  line-height: 1.7;
 }
+
+main {
+  max-width: var(--page-max-width);
+  width: 100%;
+  margin: 0 auto;
+  padding-inline: 0;
+}
+
+@media (max-width: 900px) {
+  main {
+    max-width: var(--page-max-width-compact);
+  }
+}
+
+@media (max-width: 640px) {
+  main {
+    max-width: 100%;
+    padding-inline: 1.25rem;
+  }
+}
+
 b,
 strong,
 h3,
@@ -48,6 +78,24 @@ h1 {
 }
 h2 {
   font-variation-settings: 'wght' 750;
+}
+
+p,
+li {
+  color: var(--text-secondary);
+}
+
+a {
+  color: #1d4ed8;
+  text-decoration-color: rgba(29, 78, 216, 0.45);
+  text-decoration-thickness: 2px;
+  transition: color 150ms ease, text-decoration-color 150ms ease;
+}
+
+a:hover,
+a:focus {
+  color: #1e3a8a;
+  text-decoration-color: rgba(30, 58, 138, 0.55);
 }
 
 @media screen and (min-device-pixel-ratio: 1.5),
@@ -66,12 +114,25 @@ img.next-image {
   margin: 0;
 }
 
+.prose,
+.nextra-content {
+  color: var(--text-secondary);
+}
+
+.prose :where(p, li) {
+  color: var(--text-secondary);
+}
+
+.prose :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--text-primary);
+}
+
 .prose a {
-  color: #0074de;
+  color: #1d4ed8;
 }
 
 .nav-line .nav-link {
-  color: #69778c;
+  color: #334155;
 }
 
 .art-carousel {
@@ -186,8 +247,23 @@ img.next-image {
   margin-bottom: 3.5rem;
   border-radius: 32px;
   background: linear-gradient(135deg, #0f172a 0%, #312e81 45%, #1e40af 100%);
+  background-size: 180% 180%;
+  animation: heroGradient 18s ease infinite;
   color: #f8fafc;
   box-shadow: 0 35px 70px rgba(15, 23, 42, 0.35);
+  isolation: isolate;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: -18% auto auto -22%;
+  width: clamp(160px, 32vw, 260px);
+  height: clamp(160px, 32vw, 260px);
+  background: radial-gradient(circle, rgba(248, 250, 252, 0.45), transparent 70%);
+  filter: blur(10px);
+  opacity: 0.7;
+  animation: heroFloat 14s ease-in-out infinite;
 }
 
 .hero::after {
@@ -199,6 +275,7 @@ img.next-image {
   background: radial-gradient(circle, rgba(14, 165, 233, 0.55), transparent 70%);
   filter: blur(12px);
   opacity: 0.65;
+  animation: heroFloat 18s ease-in-out infinite reverse;
 }
 
 .hero > * {
@@ -255,7 +332,7 @@ img.next-image {
 }
 
 .hero__links a {
-  color: rgba(248, 250, 252, 0.9);
+  color: rgba(248, 250, 252, 0.92);
   text-decoration: none;
   transition: color 150ms ease, transform 150ms ease;
 }
@@ -264,6 +341,20 @@ img.next-image {
 .hero__links a:focus {
   color: #e0f2fe;
   transform: translateY(-1px);
+}
+
+.hero__copy a,
+.hero__subtitle a {
+  color: #bfdbfe;
+  text-decoration-color: rgba(191, 219, 254, 0.6);
+}
+
+.hero__copy a:hover,
+.hero__copy a:focus,
+.hero__subtitle a:hover,
+.hero__subtitle a:focus {
+  color: #f8fafc;
+  text-decoration-color: rgba(248, 250, 252, 0.8);
 }
 
 .button {
@@ -276,14 +367,17 @@ img.next-image {
   background-color: #facc15;
   color: #0f172a !important;
   text-decoration: none;
-  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease,
+    filter 150ms ease;
   box-shadow: 0 18px 35px rgba(250, 204, 21, 0.35);
+  filter: brightness(1);
 }
 
 .button:hover,
 .button:focus {
   transform: translateY(-2px);
   box-shadow: 0 22px 40px rgba(250, 204, 21, 0.45);
+  filter: brightness(1.05);
 }
 
 .button:active {
@@ -305,24 +399,57 @@ img.next-image {
 }
 
 .page-section {
-  background: rgba(255, 255, 255, 0.82);
+  position: relative;
+  background: var(--surface-elevated);
   border-radius: 28px;
   padding: clamp(1.75rem, 3.5vw, 2.5rem);
   margin-bottom: 2.75rem;
   box-shadow: 0 25px 60px rgba(15, 23, 42, 0.1);
   backdrop-filter: blur(4px);
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeSlideUp 0.9s ease forwards;
+}
+
+.page-section::before {
+  content: '';
+  position: absolute;
+  inset: -45% auto auto -25%;
+  width: clamp(220px, 40vw, 320px);
+  height: clamp(220px, 40vw, 320px);
+  background: radial-gradient(circle, rgba(79, 70, 229, 0.12), transparent 70%);
+  opacity: 0.9;
+  transform: rotate(8deg);
+}
+
+.page-section > * {
+  position: relative;
+  z-index: 1;
+}
+
+.page-section:nth-of-type(2) {
+  animation-delay: 0.08s;
+}
+
+.page-section:nth-of-type(3) {
+  animation-delay: 0.16s;
+}
+
+.page-section:nth-of-type(4) {
+  animation-delay: 0.24s;
 }
 
 .section-title {
   font-size: clamp(1.75rem, 3vw, 2.3rem);
   margin-bottom: 1.5rem;
-  color: #1e293b;
+  color: var(--text-primary);
 }
 
 .page-section p {
   line-height: 1.8;
   font-size: 1.02rem;
-  color: #1e293b;
+  color: var(--text-secondary);
 }
 
 .highlight-grid {
@@ -338,6 +465,7 @@ img.next-image {
   padding: 1.75rem;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.2);
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
 }
 
 .highlight-card h3 {
@@ -364,6 +492,7 @@ img.next-image {
   background: rgba(241, 245, 249, 0.9);
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
 }
 
 .experience-card h3 {
@@ -400,6 +529,7 @@ img.next-image {
   color: #1e3a8a;
   font-weight: 600;
   font-size: 0.9rem;
+  transition: transform 200ms ease, box-shadow 200ms ease, background-color 200ms ease;
 }
 
 .page-hero {
@@ -439,6 +569,7 @@ img.next-image {
   padding: clamp(1.75rem, 4vw, 2.5rem);
   border: 1px solid rgba(148, 163, 184, 0.22);
   box-shadow: 0 25px 55px rgba(15, 23, 42, 0.12);
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
 }
 
 .project-card__tag {
@@ -482,6 +613,62 @@ img.next-image {
   gap: 1rem;
 }
 
+.highlight-card:hover,
+.highlight-card:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(30, 64, 175, 0.25);
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.12);
+}
+
+.experience-card:hover,
+.experience-card:focus-within,
+.project-card:hover,
+.project-card:focus-within {
+  transform: translateY(-8px);
+  border-color: rgba(59, 130, 246, 0.28);
+  box-shadow: 0 30px 50px rgba(15, 23, 42, 0.18);
+}
+
+.skill-badge:hover,
+.skill-badge:focus {
+  transform: translateY(-3px);
+  background: rgba(30, 64, 175, 0.16);
+  box-shadow: 0 12px 20px rgba(30, 64, 175, 0.18);
+}
+
+@keyframes heroGradient {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes heroFloat {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(12px, -16px, 0) scale(1.05);
+  }
+}
+
+@keyframes fadeSlideUp {
+  0% {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (max-width: 640px) {
   .hero {
     border-radius: 24px;
@@ -499,5 +686,25 @@ img.next-image {
 
   .project-card {
     padding: 1.6rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .hero,
+  .hero::before,
+  .hero::after,
+  .page-section {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- update the homepage hero, highlights, and experience sections to focus on the BRAINML Lab role and a 2026 full-time search
- refresh the projects page intro and call-to-action to reflect ongoing EEG research and new availability
- overhaul global styles with higher-contrast typography, wider layout constraints, and animated accents for cards and hero

## Testing
- CI=1 yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cc3cd7a0308320ab267ebd1253795c