### PR TITLE
Improve readability and tighten experience timeline

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -75,42 +75,62 @@ date: 2021-03-19
 
 <section className="page-section fade-in delay-2">
   <h2 className="section-title">Recent Experience</h2>
-  <div className="experience-grid">
-    <article className="experience-card">
-      <h3>Georgia Tech · BRAINML Lab</h3>
-      <span>Graduate Researcher · 2024 – Present</span>
-      <ul>
-        <li>Analyze multi-session EEG datasets to surface biomarkers for cognitive workload and attention.</li>
-        <li>Develop interactive dashboards and signal-processing pipelines that accelerate lab experimentation.</li>
-        <li>Prototype deep learning models and interpretability workflows for real-time neuroadaptive systems.</li>
-      </ul>
+  <div className="experience-timeline">
+    <article className="timeline-entry">
+      <div className="timeline-entry__meta">
+        <span className="timeline-entry__date">2024 – Present</span>
+      </div>
+      <div className="timeline-entry__card">
+        <h3>Georgia Tech · BRAINML Lab</h3>
+        <p className="timeline-entry__role">Graduate Researcher</p>
+        <ul>
+          <li>Analyze multi-session EEG datasets to surface biomarkers for cognitive workload and attention.</li>
+          <li>Develop interactive dashboards and signal-processing pipelines that accelerate lab experimentation.</li>
+          <li>Prototype deep learning models and interpretability workflows for real-time neuroadaptive systems.</li>
+        </ul>
+      </div>
     </article>
-    <article className="experience-card">
-      <h3>Carl Zeiss XRM</h3>
-      <span>Cloud &amp; AI Engineer · 2025</span>
-      <ul>
-        <li>Re-architected AI-based 3D reconstruction pipelines on Azure to achieve a 10× performance boost.</li>
-        <li>Containerized imaging services with Docker to support microservice-style deployments.</li>
-        <li>Integrated deep-learning denoising into automated scientific workflows for researchers.</li>
-      </ul>
+    <article className="timeline-entry">
+      <div className="timeline-entry__meta">
+        <span className="timeline-entry__date">2025</span>
+      </div>
+      <div className="timeline-entry__card">
+        <h3>Carl Zeiss XRM</h3>
+        <p className="timeline-entry__role">Cloud &amp; AI Engineer</p>
+        <ul>
+          <li>Re-architected AI-based 3D reconstruction pipelines on Azure to achieve a 10× performance boost.</li>
+          <li>Containerized imaging services with Docker to support microservice-style deployments.</li>
+          <li>Integrated deep-learning denoising into automated scientific workflows for researchers.</li>
+        </ul>
+      </div>
     </article>
-    <article className="experience-card">
-      <h3>Walmart</h3>
-      <span>Software Engineer III · 2021 – 2024</span>
-      <ul>
-        <li>Directed the Quick Mods microfrontend rollout, cutting layout publishing time to 10 days.</li>
-        <li>Published a StoreMap embedding SDK on NPM and supported a React Native app for on-the-go updates.</li>
-        <li>Collaborated with product and design partners to launch omnichannel experiences with measurable lift.</li>
-      </ul>
+    <article className="timeline-entry">
+      <div className="timeline-entry__meta">
+        <span className="timeline-entry__date">2021 – 2024</span>
+      </div>
+      <div className="timeline-entry__card">
+        <h3>Walmart</h3>
+        <p className="timeline-entry__role">Software Engineer III</p>
+        <ul>
+          <li>Directed the Quick Mods microfrontend rollout, cutting layout publishing time to 10 days.</li>
+          <li>Published a StoreMap embedding SDK on NPM and supported a React Native app for on-the-go updates.</li>
+          <li>Collaborated with product and design partners to launch omnichannel experiences with measurable lift.</li>
+        </ul>
+      </div>
     </article>
-    <article className="experience-card">
-      <h3>Siemens</h3>
-      <span>Software Engineer · 2019 – 2021</span>
-      <ul>
-        <li>Shipped full-stack features for the Active Workspace platform across React, C++, and MySQL services.</li>
-        <li>Resolved P0 production incidents under aggressive SLAs in a globally distributed codebase.</li>
-        <li>Partnered with enterprise customers to secure multimillion-dollar contracts.</li>
-      </ul>
+    <article className="timeline-entry">
+      <div className="timeline-entry__meta">
+        <span className="timeline-entry__date">2019 – 2021</span>
+      </div>
+      <div className="timeline-entry__card">
+        <h3>Siemens</h3>
+        <p className="timeline-entry__role">Software Engineer</p>
+        <ul>
+          <li>Shipped full-stack features for the Active Workspace platform across React, C++, and MySQL services.</li>
+          <li>Resolved P0 production incidents under aggressive SLAs in a globally distributed codebase.</li>
+          <li>Partnered with enterprise customers to secure multimillion-dollar contracts.</li>
+        </ul>
+      </div>
     </article>
   </div>
 </section>

--- a/styles/main.css
+++ b/styles/main.css
@@ -44,7 +44,7 @@ body {
 main article {
   margin-left: auto;
   margin-right: auto;
-  max-width: min(1180px, calc(100vw - 3rem));
+  max-width: min(1320px, calc(100vw - 3rem));
 }
 
 @media (max-width: 768px) {
@@ -164,7 +164,13 @@ img.next-image {
 }
 
 .nav-line .nav-link {
-  color: #69778c;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.nav-line .nav-link:hover,
+.nav-line .nav-link:focus {
+  color: #1d4ed8;
 }
 
 .art-carousel {
@@ -322,17 +328,21 @@ img.next-image {
   gap: 0.5rem;
   padding: 0.45rem 1.1rem;
   border-radius: 9999px;
-  background-color: rgba(248, 250, 252, 0.15);
+  background-color: rgba(248, 250, 252, 0.22);
+  color: rgba(248, 250, 252, 0.94);
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.72rem;
   font-weight: 600;
   margin-bottom: 1.25rem;
+  text-shadow: 0 6px 18px rgba(15, 23, 42, 0.55);
 }
 
 .hero__title {
   font-size: clamp(2.75rem, 5vw, 4.5rem);
   margin: 0 0 1rem;
+  color: #f8fafc;
+  text-shadow: 0 18px 45px rgba(15, 23, 42, 0.55);
 }
 
 .hero__subtitle {
@@ -340,6 +350,8 @@ img.next-image {
   max-width: 680px;
   margin-bottom: 1.5rem;
   line-height: 1.6;
+  color: rgba(241, 245, 249, 0.95);
+  text-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
 }
 
 .hero__copy {
@@ -347,14 +359,16 @@ img.next-image {
   font-size: 1.05rem;
   line-height: 1.8;
   margin-bottom: 2rem;
+  color: rgba(226, 232, 240, 0.92);
 }
 
 .hero__copy--accent {
-  background: rgba(248, 250, 252, 0.12);
+  background: rgba(248, 250, 252, 0.22);
+  color: rgba(241, 245, 249, 0.97);
   border-left: 3px solid rgba(250, 204, 21, 0.65);
   padding: 1rem 1.25rem;
   border-radius: 18px;
-  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.25);
+  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.35);
 }
 
 .hero__cta {
@@ -373,15 +387,33 @@ img.next-image {
 }
 
 .hero__links a {
-  color: rgba(248, 250, 252, 0.9);
+  position: relative;
+  color: rgba(248, 250, 252, 0.96);
   text-decoration: none;
   transition: color 150ms ease, transform 150ms ease;
+}
+
+.hero__links a::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 -4px;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(248, 250, 252, 0.2), rgba(255, 255, 255, 0.75));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 180ms ease;
+  opacity: 0.85;
 }
 
 .hero__links a:hover,
 .hero__links a:focus {
   color: #e0f2fe;
   transform: translateY(-1px);
+}
+
+.hero__links a:hover::after,
+.hero__links a:focus::after {
+  transform: scaleX(1);
 }
 
 .button {
@@ -423,10 +455,10 @@ img.next-image {
 }
 
 .page-section {
-  background: rgba(255, 255, 255, 0.82);
+  background: rgba(255, 255, 255, 0.92);
   border-radius: 28px;
-  padding: clamp(1.75rem, 3.5vw, 2.5rem);
-  margin-bottom: 2.75rem;
+  padding: clamp(1.85rem, 3.5vw, 2.7rem);
+  margin-bottom: 2.25rem;
   box-shadow: 0 25px 60px rgba(15, 23, 42, 0.1);
   backdrop-filter: blur(4px);
   transition: transform 350ms ease, box-shadow 350ms ease;
@@ -435,13 +467,13 @@ img.next-image {
 .section-title {
   font-size: clamp(1.75rem, 3vw, 2.3rem);
   margin-bottom: 1.5rem;
-  color: #1e293b;
+  color: #0b1120;
 }
 
 .page-section p {
   line-height: 1.8;
   font-size: 1.02rem;
-  color: #1e293b;
+  color: #0f172a;
 }
 
 .page-section:hover {
@@ -469,11 +501,12 @@ img.next-image {
   margin-top: 0;
   margin-bottom: 0.75rem;
   font-size: 1.2rem;
+  color: #0b1120;
 }
 
 .highlight-card p {
   margin: 0;
-  color: #334155;
+  color: #0f172a;
 }
 
 .highlight-card:hover {
@@ -481,63 +514,169 @@ img.next-image {
   box-shadow: 0 22px 45px rgba(30, 64, 175, 0.2);
 }
 
-.experience-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.75rem;
-  margin-top: 1.75rem;
-}
-
-.experience-card {
-  border-radius: 20px;
-  padding: 1.75rem;
-  background: rgba(241, 245, 249, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+.experience-timeline {
+  --timeline-offset: clamp(0.85rem, 2.5vw, 1.2rem);
+  --timeline-marker-size: 0.85rem;
   position: relative;
-  overflow: hidden;
+  display: grid;
+  gap: clamp(1.25rem, 2.5vw, 2.15rem);
+  margin-top: clamp(1.25rem, 2.5vw, 2.1rem);
+  padding-left: calc(var(--timeline-offset) + 0.75rem);
 }
 
-.experience-card::after {
+.experience-timeline::before {
   content: '';
   position: absolute;
-  inset: auto auto -20% -20%;
-  width: 180px;
-  height: 180px;
-  background: radial-gradient(circle, rgba(129, 140, 248, 0.2), transparent 70%);
+  top: 0.75rem;
+  bottom: 0.75rem;
+  left: var(--timeline-offset);
+  width: 3px;
+  border-radius: 9999px;
+  background: linear-gradient(
+    180deg,
+    rgba(148, 163, 184, 0),
+    rgba(148, 163, 184, 0.45) 12%,
+    rgba(59, 130, 246, 0.55) 88%,
+    rgba(59, 130, 246, 0)
+  );
+  pointer-events: none;
+}
+
+.timeline-entry {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.35fr) 1fr;
+  gap: clamp(1.25rem, 2.75vw, 2.25rem);
+  align-items: start;
+}
+
+.timeline-entry__meta {
+  position: relative;
+  padding-left: calc(var(--timeline-offset) + 1.6rem);
+  color: #0b1120;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.timeline-entry__meta::before {
+  content: '';
+  position: absolute;
+  left: calc(var(--timeline-offset) - var(--timeline-marker-size) / 2);
+  top: 0.4rem;
+  width: var(--timeline-marker-size);
+  height: var(--timeline-marker-size);
+  border-radius: 9999px;
+  background: #facc15;
+  box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.25), 0 14px 28px rgba(15, 23, 42, 0.25);
+  transition: transform 220ms ease, box-shadow 220ms ease;
+  z-index: 1;
+}
+
+.timeline-entry__date {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.95rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  color: #0b1120;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+}
+
+.timeline-entry__card {
+  position: relative;
+  border-radius: 22px;
+  padding: clamp(1.5rem, 3vw, 2.2rem);
+  background: rgba(248, 250, 252, 0.94);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.timeline-entry__card::after {
+  content: '';
+  position: absolute;
+  inset: auto -15% -35% auto;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgba(96, 165, 250, 0.18), transparent 70%);
   z-index: 0;
   transition: transform 220ms ease, opacity 220ms ease;
 }
 
-.experience-card h3 {
+.timeline-entry__card h3 {
   margin-top: 0;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.35rem;
+  position: relative;
+  z-index: 1;
+  color: #0b1120;
+}
+
+.timeline-entry__role {
+  margin: 0 0 1.1rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #0f172a;
   position: relative;
   z-index: 1;
 }
 
-.experience-card span {
-  display: block;
-  font-size: 0.9rem;
-  color: #475569;
-  margin-bottom: 1rem;
-  position: relative;
-  z-index: 1;
-}
-
-.experience-card ul {
+.timeline-entry__card ul {
   padding-left: 1.1rem;
   margin: 0;
   display: grid;
-  gap: 0.65rem;
-  color: #334155;
+  gap: 0.6rem;
+  color: #0f172a;
   position: relative;
   z-index: 1;
 }
 
-.experience-card:hover::after {
-  transform: translate(10%, -10%);
-  opacity: 0.9;
+.timeline-entry__card li {
+  line-height: 1.75;
+}
+
+.timeline-entry:hover .timeline-entry__card {
+  transform: translateY(-8px);
+  box-shadow: 0 32px 70px rgba(30, 64, 175, 0.18);
+}
+
+.timeline-entry:hover .timeline-entry__card::after {
+  transform: translate(-6%, -18%);
+  opacity: 0.95;
+}
+
+.timeline-entry:hover .timeline-entry__meta::before {
+  transform: scale(1.15);
+  box-shadow: 0 0 0 6px rgba(250, 204, 21, 0.3), 0 18px 32px rgba(15, 23, 42, 0.28);
+}
+
+@media (max-width: 900px) {
+  .timeline-entry {
+    grid-template-columns: minmax(140px, 0.45fr) 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .experience-timeline {
+    padding-left: calc(var(--timeline-offset) + 0.25rem);
+  }
+
+  .timeline-entry {
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+  }
+
+  .timeline-entry__meta {
+    padding-left: calc(var(--timeline-offset) + 1.4rem);
+  }
+
+  .timeline-entry__card {
+    padding: 1.5rem;
+  }
 }
 
 .skill-badges {


### PR DESCRIPTION
## Summary
- expand the page container width for a roomier desktop layout and darken navigation link styling for better contrast
- raise section, card, and timeline typography contrast against light backgrounds
- tighten gaps in the experience timeline to produce a denser, easier-to-scan progression

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc425a3bf483209729a52dffeb36d8