### PR TITLE
Improve default text contrast across site

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -37,6 +37,19 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+body :where(p, li, span, strong, em, blockquote, figcaption, time,
+        small, label) {
+  color: #0f172a;
+}
+
+body :where(h1, h2, h3, h4, h5, h6) {
+  color: #0b1120;
+}
+
+body :where(code, pre) {
+  color: #0b1120;
+}
+
 :root {
   color: #0f172a;
 }


### PR DESCRIPTION
## Summary
- enforce a dark text color for body copy, inline elements, and headings to improve contrast on light backgrounds
- ensure code blocks inherit the darker palette so that all content remains legible outside the hero section

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cc5e6a3e808320ba52f06630224873