### PR TITLE
Add persistent top navigation with projects tab

### DIFF
--- a/components/SiteNav.js
+++ b/components/SiteNav.js
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+const NAV_LINKS = [
+  { href: '/', label: 'About', match: /^\/$/ },
+  { href: '/projects', label: 'Projects', match: /^\/projects(\/.*)?$/ },
+  { href: '/art', label: 'Art', match: /^\/art(\/.*)?$/ },
+  { href: '/posts', label: 'Blog', match: /^\/posts(\/.*)?$/ }
+]
+
+export default function SiteNav() {
+  const { asPath } = useRouter()
+
+  return (
+    <nav className="site-nav" aria-label="Main">
+      <div className="site-nav__container">
+        {NAV_LINKS.map(({ href, label, match }) => {
+          const isActive = match.test(asPath)
+          const className = `site-nav__link${isActive ? ' site-nav__link--active' : ''}`
+
+          if (isActive) {
+            return (
+              <span key={href} className={className} aria-current="page">
+                {label}
+              </span>
+            )
+          }
+
+          return (
+            <Link key={href} href={href} legacyBehavior>
+              <a className={className}>{label}</a>
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import { Analytics } from '@vercel/analytics/react'
 
 import '../styles/main.css'
+import SiteNav from '../components/SiteNav'
 
 export default function Nextra({ Component, pageProps }) {
   return (
@@ -23,6 +24,7 @@ export default function Nextra({ Component, pageProps }) {
           crossOrigin="anonymous"
         />
       </Head>
+      <SiteNav />
       <Component {...pageProps} />
       <SpeedInsights />
       <Analytics />

--- a/styles/main.css
+++ b/styles/main.css
@@ -218,6 +218,84 @@ img.next-image {
   color: #1d4ed8;
 }
 
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: center;
+  padding: 1.25rem 0 0.5rem;
+  background: linear-gradient(
+      180deg,
+      rgba(248, 250, 252, 0.94),
+      rgba(248, 250, 252, 0.75)
+    )
+    fixed;
+  backdrop-filter: blur(10px);
+}
+
+.site-nav__container {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem;
+  border-radius: 9999px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.site-nav__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.1rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-heading);
+  text-decoration: none;
+  transition: all 150ms ease;
+}
+
+.site-nav__link:hover,
+.site-nav__link:focus {
+  color: #1d4ed8;
+  background-color: rgba(59, 130, 246, 0.1);
+}
+
+.site-nav__link--active {
+  background: linear-gradient(135deg, #1d4ed8, #312e81);
+  color: #f8fafc;
+  box-shadow: 0 16px 32px rgba(30, 64, 175, 0.35);
+  cursor: default;
+}
+
+.site-nav__link--active:hover,
+.site-nav__link--active:focus {
+  color: #f8fafc;
+}
+
+@media (max-width: 768px) {
+  .site-nav {
+    padding: 1rem 0 0.5rem;
+  }
+
+  .site-nav__container {
+    gap: 0.25rem;
+    padding: 0.3rem;
+  }
+
+  .site-nav__link {
+    font-size: 0.9rem;
+    padding: 0.45rem 0.9rem;
+  }
+}
+
+article > .nx-mb-8.nx-flex {
+  display: none;
+}
+
 .art-carousel {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a dedicated `SiteNav` component that renders About, Projects, Art, and Blog links on every page
- mount the custom navigation in `_app.js` and hide the theme-provided tabs
- style the new navigation as a sticky pill bar so the Projects tab always remains visible

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cc688e94f4832093330091b86df3d9