### PR TITLE
Expand content width on large screens

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -92,6 +92,16 @@ main article {
   max-width: min(1320px, calc(100vw - 3rem));
 }
 
+.nx-prose {
+  width: 100%;
+}
+
+@media (min-width: 1024px) {
+  .nx-prose {
+    max-width: min(65vw, 1320px);
+  }
+}
+
 @media (max-width: 768px) {
   main article {
     max-width: calc(100vw - 2rem);


### PR DESCRIPTION
## Summary
- allow the prose container to grow with the article width and cap at 65% of the viewport on large screens so content uses more horizontal space

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cc72d0016c83208a8af7f0a3e7ac05